### PR TITLE
uniq names for users.sls

### DIFF
--- a/zabbix/users.sls
+++ b/zabbix/users.sls
@@ -2,15 +2,15 @@
 {% set settings = salt['pillar.get']('zabbix', {}) %}
 
 
-zabbix_user:
+zabbix-formula_zabbix_user:
   user.present:
     - name: {{ zabbix.user }}
     - gid_from_name: True
     - groups: {{ settings.get('user_groups', []) }}
     - require:
-      - group: zabbix_group
+      - group: zabbix-formula_zabbix_group
 
 
-zabbix_group:
+zabbix-formula_zabbix_group:
   group.present:
     - name: {{ zabbix.group }}


### PR DESCRIPTION
Hello! Fix bugs plz!  Users must using uniq values!
 remote:     Data failed to compile:
 remote: ----------
 remote:     Detected conflicting IDs, SLS IDs need to be globally unique.
 remote:     The conflicting ID is 'zabbix_user' and is found in SLS 'base:users' and SLS 'base:zabbix.users'
