### PR TITLE
Added default logfile location for Debian systems to map.jinja, using it...

### DIFF
--- a/zabbix/files/default/etc/zabbix/zabbix_agentd.conf.jinja
+++ b/zabbix/files/default/etc/zabbix/zabbix_agentd.conf.jinja
@@ -1,9 +1,10 @@
 # Managed by saltstack
+{% from "zabbix/map.jinja" import zabbix with context -%}
 {% set settings = salt['pillar.get']('zabbix-agent', {}) -%}
 PidFile={{ settings.get('pidfile', '/tmp/zabbix_agentd.pid') }}
 {% if settings.get('logfile', '/var/log/zabbix/zabbix_agentd.log') !=
        "syslog" -%}
-LogFile={{ settings.get('logfile', '/var/log/zabbix/zabbix_agentd.log') }}
+LogFile={{ settings.get('logfile', zabbix.agent.logfile) }}
 {%- endif %}
 LogFileSize=0
 Server={{ settings.get('server', 'localhost') }}

--- a/zabbix/map.jinja
+++ b/zabbix/map.jinja
@@ -6,7 +6,8 @@
     'agent': {
       'pkg': 'zabbix-agent',
       'service': 'zabbix-agent',
-      'config': '/etc/zabbix/zabbix_agentd.conf'
+      'config': '/etc/zabbix/zabbix_agentd.conf',
+      'logfile': '/var/log/zabbix-agent/zabbix_agentd.log'
     },
     'server': {
       'pkg': 'zabbix-server-mysql',
@@ -55,6 +56,7 @@
       'pkg': 'zabbix-agent',
       'service': 'zabbix-agent',
       'config': '/etc/zabbix/zabbix_agentd.conf'
+      'logfile': '/var/log/zabbix/zabbix_agentd.log'
     },
     'server': {
       'pkg': 'zabbix-server-mysql',


### PR DESCRIPTION
... for the agent config

By default the zabbix-agent won't work i. e. in Ubuntu where the logfile location is different, unless you explicitly state the logfile in your pillar. The agent will crash upon start because it can't write into the directory.

This is just a starter, but you could use your map.jinja to get OS specific defaults into your config templates as well.