### PR TITLE
ListenIP being set to default 0.0.0.0

### DIFF
--- a/zabbix/files/default/etc/zabbix/zabbix_agentd.conf.jinja
+++ b/zabbix/files/default/etc/zabbix/zabbix_agentd.conf.jinja
@@ -9,7 +9,7 @@ LogFileSize=0
 Server={{ settings.get('server', 'localhost') }}
 ListenPort={{ settings.get('listenport', '10050') }}
 {% if settings.get('listenip', false) -%}
-ListenIP={{ settings.get('listenip', '0.0.0.0') }}
+ListenIP={{ settings.get('listenip') }}
 {%- endif %}
 ServerActive={{ settings.get('serveractive', '') }}
 Hostname={{ settings.get('hostname', salt['grains.get']('id')) }}

--- a/zabbix/files/default/etc/zabbix/zabbix_agentd.conf.jinja
+++ b/zabbix/files/default/etc/zabbix/zabbix_agentd.conf.jinja
@@ -8,7 +8,9 @@ LogFile={{ settings.get('logfile', '/var/log/zabbix/zabbix_agentd.log') }}
 LogFileSize=0
 Server={{ settings.get('server', 'localhost') }}
 ListenPort={{ settings.get('listenport', '10050') }}
+{% if settings.get('listenip', false) -%}
 ListenIP={{ settings.get('listenip', '0.0.0.0') }}
+{%- endif %}
 ServerActive={{ settings.get('serveractive', '') }}
 Hostname={{ settings.get('hostname', salt['grains.get']('id')) }}
 {% if settings.get('hostmetadata', false) -%}


### PR DESCRIPTION
Hi,

due to this documented behaviour in Zabbix active agent auto-registration, always setting the ListenIP parameter in zabbix_agentd.conf to default 0.0.0.0 can be problematic:

>Active agent auto-registration also supports the monitoring of added hosts with passive checks. When the active agent asks for checks, providing it has the 'ListenIP' or 'ListenPort' configuration parameters defined in the configuration file, these are sent along to the server. (If multiple IP addresses are specified, the first one is sent to the server.)

https://www.zabbix.com/documentation/2.2/manual/discovery/auto_registration

Active agent auto-registration reads the explicitly set value from ListenIP and sends it to the Zabbix server, which will set 0.0.0.0 as the agent interface during auto-registration. This renders any passive checks unusable.

If however the ListenIP parameter is omitted, the correct IP address will be sent to the Zabbix server, even if the Zabbix agent internally defaults the ListenIP value to 0.0.0.0. (https://www.zabbix.com/documentation/2.2/manual/appendix/config/zabbix_agentd)

This is a little inconsistent behaviour from the Zabbix agent, but I suggest not setting ListenIP unless it is explicitly requested by pillar data.

Best regards,
Jacob

