### PR TITLE
Specifically disable Recommends for zabbix-server

### DIFF
--- a/zabbix/server/init.sls
+++ b/zabbix/server/init.sls
@@ -7,6 +7,9 @@ zabbix-server:
     {% if zabbix.server.version is defined -%}
     - version: {{ zabbix.server.version }}
     {%- endif %}
+    {% if salt['grains.get']('os_family') == 'Debian' -%}
+    - install_recommends: False
+    {% endif %}
   service.running:
     - name: {{ zabbix.server.service }}
     - enable: True

--- a/zabbix/server/repo.sls
+++ b/zabbix/server/repo.sls
@@ -26,18 +26,3 @@ extend:
         - pkg: zabbix-server
     {%- else %} {}
     {%- endif %}
-
-
-# IMPORTANT NOTE: This is needed in Debian to ensure that installing the
-# server doesn't trigger a install of mysql-server. The official package of
-# zabbix-server-mysql "recommends" mysql-server which forces a default install
-# with server + db in the same host... which is not always what we want.
-# There's no way so far to tell the apt pkg state module something as the
-# "--without-recommends" flag just for a package.
-{% if salt['grains.get']('os_family') == 'Debian' -%}
-/etc/apt/apt.conf.d/00local-disable-recommends:
-  file.managed:
-    - contents: 'APT::Install-Recommends "false";'
-    - require_in:
-      - pkgrepo: zabbix_server_repo
-{%- endif %}


### PR DESCRIPTION
The code removed in this commit was written to ensure that the
installation of the zabbix-server package does not pull in the
mysql-server package via Recommends on Debian. The way it was written
did, however, disable the installation of *any* recommended package
globally and outwith the scope of this formula.

One problematic aspect of this approach is that it requires users to use
at least salt 2015.5.0 as setting "install_recommends" was not supported
before.

This fixes #19