### PR TITLE
Added default value for LogFileSize (agent option)

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -26,6 +26,7 @@ zabbix-agent:
   serveractive: localhost
   hostmetadata: c9767034-22c6-4d3d-a886-5fcaf1386b77
   logfile: /var/log/zabbix/zabbix_agentd.log
+  logfilesize: 0
   include: /etc/zabbix/zabbix_agentd.d/
   userparameters:
     - net.ping[*],/usr/bin/fping -q -c3 $1 2>&1 | sed 's,.*/\([0-9.]*\)/.*,\1,'


### PR DESCRIPTION
Since #21 removed hardcoded value, we'll put it back with pillar.
Historically `LogFileSize` was set as 0 both in deb package's and salt's version of config.