### PR TITLE
Added packages zabbix_sender to agent, zabbix_get to server and proxy

### DIFF
--- a/zabbix/agent/init.sls
+++ b/zabbix/agent/init.sls
@@ -3,8 +3,11 @@
 
 zabbix-agent:
   pkg.installed:
-    - name: {{ zabbix.agent.pkg }}
-    {% if zabbix.agent.version is defined -%}
+    - pkgs:
+      {%- for name in zabbix.agent.pkgs %}
+      - {{ name }}
+      {%- endfor %}
+    {%- if zabbix.agent.version is defined %}
     - version: {{ zabbix.agent.version }}
     {%- endif %}
   service.running:

--- a/zabbix/frontend/init.sls
+++ b/zabbix/frontend/init.sls
@@ -3,7 +3,10 @@
 
 zabbix-frontend-php:
   pkg.installed:
-    - name: {{ zabbix.frontend.pkg }}
+    - pkgs:
+      {%- for name in zabbix.agent.pkgs %}
+      - {{ name }}
+      {%- endfor %}
     {% if zabbix.frontend.version is defined -%}
     - version: {{ zabbix.frontend.version }}
     {%- endif %}

--- a/zabbix/map.jinja
+++ b/zabbix/map.jinja
@@ -4,22 +4,22 @@
     'user': 'zabbix',
     'group': 'zabbix',
     'agent': {
-      'pkg': 'zabbix-agent',
+      'pkgs': ['zabbix-agent', 'zabbix-sender'],
       'service': 'zabbix-agent',
       'config': '/etc/zabbix/zabbix_agentd.conf'
     },
     'server': {
-      'pkg': 'zabbix-server-mysql',
+      'pkgs': ['zabbix-server-mysql', 'zabbix-get'],
       'service': 'zabbix-server',
       'config': '/etc/zabbix/zabbix_server.conf',
       'dbsocket': '/var/run/mysqld/mysqld.sock',
     },
     'frontend': {
-      'pkg': 'zabbix-frontend-php',
+      'pkgs': ['zabbix-frontend-php'],
       'config': '/etc/zabbix/web/zabbix.conf.php'
     },
     'proxy': {
-      'pkg': 'zabbix-proxy-sqlite3',
+      'pkgs': ['zabbix-proxy-sqlite3', 'zabbix-get'],
       'service': 'zabbix-proxy',
       'config': '/etc/zabbix/zabbix_proxy.conf',
       'dbname': '/var/lib/zabbix/zabbix_proxy.db'
@@ -30,18 +30,18 @@
     'user': 'zabbix',
     'group': 'zabbix',
     'agent': {
-      'pkg': 'zabbix22-agent',
+      'pkgs': ['zabbix22-agent'],
       'service': 'zabbix_agentd',
       'config': '/usr/local/etc/zabbix22/zabbix_agentd.conf'
     },
     'server': {
-      'pkg': 'zabbix22-server',
+      'pkgs': ['zabbix22-server'],
       'service': 'zabbix',
       'config': '/usr/local/etc/zabbix22/zabbix_server.conf',
       'dbsocket': '/var/run/mysqld/mysqld.sock',
     },
     'proxy': {
-      'pkg': 'zabbix22-proxy',
+      'pkgs': ['zabbix22-proxy'],
       'service': 'zabbix_proxy',
       'config': '/usr/local/etc/zabbix22/zabbix_proxy.conf',
       'dbname': '/var/lib/zabbix/zabbix_proxy.db'
@@ -53,22 +53,22 @@
     'user': 'zabbix',
     'group': 'zabbix',
     'agent': {
-      'pkg': 'zabbix-agent',
+      'pkgs': ['zabbix-agent', 'zabbix-sender'],
       'service': 'zabbix-agent',
       'config': '/etc/zabbix/zabbix_agentd.conf'
     },
     'server': {
-      'pkg': 'zabbix-server-mysql',
+      'pkgs': ['zabbix-server-mysql', 'zabbix-get'],
       'service': 'zabbix-server',
       'config': '/etc/zabbix/zabbix_server.conf',
       'dbsocket': '/var/lib/mysql/mysql.sock',
     },
     'frontend': {
-      'pkg': 'zabbix-web-mysql',
+      'pkgs': ['zabbix-web-mysql'],
       'config': '/etc/zabbix/web/zabbix.conf.php'
     },
     'proxy': {
-      'pkg': 'zabbix-proxy-sqlite3',
+      'pkgs': ['zabbix-proxy-sqlite3', 'zabbix-get'],
       'service': 'zabbix-proxy',
       'config': '/etc/zabbix/zabbix_proxy.conf',
       'dbname': '/var/lib/zabbix/zabbix_proxy.db'

--- a/zabbix/proxy/init.sls
+++ b/zabbix/proxy/init.sls
@@ -3,10 +3,14 @@
 
 zabbix-proxy:
   pkg.installed:
-    - name: {{ zabbix.proxy.pkg }}
+    - pkgs:
+      {%- for name in zabbix.proxy.pkgs %}
+      - {{ name }}
+      {%- endfor %}
     {% if zabbix.proxy.version is defined -%}
     - version: {{ zabbix.proxy.version }}
     {%- endif %}
+  {% endfor -%}
   service.running:
     - name: {{ zabbix.proxy.service }}
     - enable: True

--- a/zabbix/server/init.sls
+++ b/zabbix/server/init.sls
@@ -3,8 +3,11 @@
 
 zabbix-server:
   pkg.installed:
-    - name: {{ zabbix.server.pkg }}
-    {% if zabbix.server.version is defined -%}
+    - pkgs:
+      {%- for name in zabbix.server.pkgs %}
+      - {{ name }}
+      {%- endfor %}
+    {%- if zabbix.server.version is defined %}
     - version: {{ zabbix.server.version }}
     {%- endif %}
     {% if salt['grains.get']('os_family') == 'Debian' -%}


### PR DESCRIPTION
Hi there,

Zabbix also comes with two cli tools: zabbix_sender and zabbix_get. Sender belongs with the agent, get belongs with (at least) server and proxy.

This PR installs updates the formula to have zabbix_sender installed as part of the zabbix_agent state, zabbix_get as part of the server and proxy states.