### PR TITLE
OpenBSD-support (for the agent only)

### DIFF
--- a/zabbix/map.jinja
+++ b/zabbix/map.jinja
@@ -75,6 +75,17 @@
     }
   },
 
+  'OpenBSD': {
+    'version_repo': '2.4',
+    'user': '_zabbix',
+    'group': '_zabbix',
+    'agent': {
+      'pkgs': ['zabbix-agent'],
+      'service': 'zabbix_agentd',
+      'config': '/etc/zabbix/zabbix_agentd.conf'
+    },
+  },
+
   'default': {
     'version_repo': '2.2',
     'user': 'zabbix',

--- a/zabbix/users.sls
+++ b/zabbix/users.sls
@@ -7,6 +7,8 @@ zabbix_user:
     - name: {{ zabbix.user }}
     - gid_from_name: True
     - groups: {{ settings.get('user_groups', []) }}
+    # Home directory should be created by pkg scripts
+    - createhome: False
     - require:
       - group: zabbix_group
 


### PR DESCRIPTION
Quick addition for the Zabbix-agent on OpenBSD
and a fix to keep `/nonexistent` nonexistent on the BSD's ;)