### PR TITLE
add "version_repo" for FreeBSD to fix agentd.conf template

### DIFF
--- a/zabbix/map.jinja
+++ b/zabbix/map.jinja
@@ -54,6 +54,7 @@
   },
 
   'FreeBSD': {
+    'version_repo': '2.2',
     'user': 'zabbix',
     'group': 'zabbix',
     'agent': {


### PR DESCRIPTION
Template for `agentd.conf` failed to render because there 
was no `'version_repo'` key for FreeBSD in `map.jinja`.