### PR TITLE
Hardcode names to correct for nonexistant pkg variables

### DIFF
--- a/zabbix/frontend/conf.sls
+++ b/zabbix/frontend/conf.sls
@@ -30,7 +30,7 @@ include:
 # We don't want the package to mess with apache
 zabbix-frontend_debconf:
   debconf.set:
-    - name: {{ zabbix.frontend.pkg}}
+    - name: zabbix-frontend-php
     - data:
         'zabbix-frontend-php/configure-apache': {'type': 'boolean',
                                                  'value': False}

--- a/zabbix/server/conf.sls
+++ b/zabbix/server/conf.sls
@@ -25,7 +25,7 @@ include:
 # We don't want to manage the db through dbconfig
 zabbix-server_debconf:
   debconf.set:
-    - name: zabbix-server
+    - name: zabbix-server-mysql
     - data:
         'zabbix-server-mysql/internal/skip-preseed': {'type': 'boolean', 'value': True}
         'zabbix-server-mysql/dbconfig-install': {'type': 'boolean', 'value': False}

--- a/zabbix/server/conf.sls
+++ b/zabbix/server/conf.sls
@@ -25,7 +25,7 @@ include:
 # We don't want to manage the db through dbconfig
 zabbix-server_debconf:
   debconf.set:
-    - name: {{ zabbix.server.pkg}}
+    - name: zabbix-server
     - data:
         'zabbix-server-mysql/internal/skip-preseed': {'type': 'boolean', 'value': True}
         'zabbix-server-mysql/dbconfig-install': {'type': 'boolean', 'value': False}


### PR DESCRIPTION
Corrects errors:
```
[ERROR   ] Rendering exception occurred: Jinja variable 'dict object' has no attribute 'pkg'
[CRITICAL] Rendering SLS 'base:zabbix.server.conf' failed: Jinja variable 'dict object' has no attribute 'pkg'
[ERROR   ] Rendering exception occurred: Jinja variable 'dict object' has no attribute 'pkg'
[CRITICAL] Rendering SLS 'base:zabbix.frontend.conf' failed: Jinja variable 'dict object' has no attribute 'pkg'
[ERROR   ] Data passed to highstate outputter is not a valid highstate return: {'local': ["Rendering SLS 'base:zabbix.server.conf' failed: Jinja variable 'dict object' has no attribute 'pkg'", "Rendering SLS 'base:zabbix.frontend.conf' failed: Jinja variable 'dict object' has no attribute 'pkg'"]}
```

I'm guessing the package names used to be saved in the map, but now those keys are nonexistent. The require entries in the same stanzas seem to use hard coded names, so converting these bits to do the same doesn't seem crazy.
