### PR TITLE
Fix MySQL ordering

### DIFF
--- a/zabbix/mysql/conf.sls
+++ b/zabbix/mysql/conf.sls
@@ -13,6 +13,10 @@ zabbix_db:
     - host: {{ dbhost }}
     - character_set: utf8
     - collate: utf8_bin
+  mysql_user.present:
+    - name: {{ dbuser }}
+    - host: '{{ dbuser_host }}'
+    - password: {{ dbpass }}
   mysql_grants.present:
     - grant: all privileges
     - database: {{ dbname }}.*
@@ -20,9 +24,4 @@ zabbix_db:
     - host: '{{ dbuser_host }}'
     - require:
       - mysql_database: zabbix_db
-  mysql_user.present:
-    - name: {{ dbuser }}
-    - host: '{{ dbuser_host }}'
-    - password: {{ dbpass }}
-    - require:
-      - mysql_grants: zabbix_db
+      - mysql_user: zabbix_db


### PR DESCRIPTION
The current ordering of grant > user causes an issue:
```
----------
          ID: zabbix_db
    Function: mysql_grants.present
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python2.7/dist-packages/salt/state.py", line 1744, in call
                  **cdata['kwargs'])
                File "/usr/lib/python2.7/dist-packages/salt/loader.py", line 1702, in wrapper
                  return f(*args, **kwargs)
                File "/usr/lib/python2.7/dist-packages/salt/states/mysql_grants.py", line 191, in present
                  grant, database, user, host, grant_option, escape, ssl_option, **connection_args
                File "/usr/lib/python2.7/dist-packages/salt/modules/mysql.py", line 1776, in grant_add
                  _execute(cur, qry['qry'], qry['args'])
                File "/usr/lib/python2.7/dist-packages/salt/modules/mysql.py", line 547, in _execute
                  return cur.execute(qry, args)
                File "/usr/lib/python2.7/dist-packages/pymysql/cursors.py", line 158, in execute
                  result = self._query(query)
                File "/usr/lib/python2.7/dist-packages/pymysql/cursors.py", line 308, in _query
                  conn.query(q)
                File "/usr/lib/python2.7/dist-packages/pymysql/connections.py", line 820, in query
                  self._affected_rows = self._read_query_result(unbuffered=unbuffered)
                File "/usr/lib/python2.7/dist-packages/pymysql/connections.py", line 1002, in _read_query_result
                  result.read()
                File "/usr/lib/python2.7/dist-packages/pymysql/connections.py", line 1285, in read
                  first_packet = self.connection._read_packet()
                File "/usr/lib/python2.7/dist-packages/pymysql/connections.py", line 966, in _read_packet
                  packet.check_error()
                File "/usr/lib/python2.7/dist-packages/pymysql/connections.py", line 394, in check_error
                  err.raise_mysql_exception(self._data)
                File "/usr/lib/python2.7/dist-packages/pymysql/err.py", line 120, in raise_mysql_exception
                  _check_mysql_exception(errinfo)
                File "/usr/lib/python2.7/dist-packages/pymysql/err.py", line 115, in _check_mysql_exception
                  raise InternalError(errno, errorvalue)
              InternalError: (1133, u"Can't find any matching row in the user table")
     Started: 15:52:45.240883
    Duration: 43.321 ms
     Changes:   
```

This PR fixes that, by making the grant depend on the user instead of the other way around.

Afterwards it works just fine:

```
ubuntu@monitoring:~$ sudo salt-call state.sls zabbix.mysql.conf
local:
----------
          ID: zabbix_db
    Function: mysql_database.present
        Name: zabbix
      Result: True
     Comment: Database zabbix is already present
     Started: 15:54:05.206120
    Duration: 5.801 ms
     Changes:   
----------
          ID: zabbix_db
    Function: mysql_user.present
        Name: zabbix
      Result: True
     Comment: The user zabbix@localhost has been added
     Started: 15:54:05.212310
    Duration: 55.939 ms
     Changes:   
              ----------
              zabbix:
                  Present
----------
          ID: zabbix_db
    Function: mysql_grants.present
      Result: True
     Comment: Grant all privileges on zabbix.* to zabbix@localhost has been added
     Started: 15:54:05.268932
    Duration: 15.79 ms
     Changes:   
              ----------
              zabbix_db:
                  Present

Summary for local
------------
Succeeded: 3 (changed=2)
Failed:    0
------------
Total states run:     3
Total run time:  77.530 ms
```

Tested on Ubuntu 16.04 with MariaDB 10.1