### PR TITLE
Handle non-local database servers during provisioning

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -52,6 +52,9 @@ zabbix-mysql:
   dbuser: zabbixuser
   dbpass: zabbixpass
   dbuser_host: '%'
+  # Optionally specify this for a non-local dbhost
+  #dbroot_user: 'root'
+  #dbroot_pass: 'rootpass'
 
 zabbix-frontend:
   dbtype: MYSQL
@@ -79,4 +82,3 @@ zabbix-proxy:
   dbname: /var/lib/zabbix/zabbix_proxy.db
   dbuser: zabbix
   include: /etc/zabbix/zabbix_proxy.d/
-

--- a/zabbix/mysql/conf.sls
+++ b/zabbix/mysql/conf.sls
@@ -6,22 +6,39 @@
 {% set dbpass = settings.get('dbpass', 'zabbixpass') -%}
 {% set dbuser_host = settings.get('dbuser_host', 'localhost') -%}
 
+{% set dbroot_user = settings.get('dbroot_user') -%}
+{% set dbroot_pass = settings.get('dbroot_pass') -%}
 
 zabbix_db:
   mysql_database.present:
     - name: {{ dbname }}
     - host: {{ dbhost }}
+    {%- if dbroot_user and dbroot_pass %}
+    - connection_host: {{ dbhost }}
+    - connection_user: {{ dbroot_user }}
+    - connection_pass: {{ dbroot_pass }}
+    {%- endif %}
     - character_set: utf8
     - collate: utf8_bin
   mysql_user.present:
     - name: {{ dbuser }}
     - host: '{{ dbuser_host }}'
     - password: {{ dbpass }}
+    {%- if dbroot_user and dbroot_pass %}
+    - connection_host: {{ dbhost }}
+    - connection_user: {{ dbroot_user }}
+    - connection_pass: {{ dbroot_pass }}
+    {%- endif %}
   mysql_grants.present:
     - grant: all privileges
     - database: {{ dbname }}.*
     - user: {{ dbuser }}
     - host: '{{ dbuser_host }}'
+    {%- if dbroot_user and dbroot_pass %}
+    - connection_host: {{ dbhost }}
+    - connection_user: {{ dbroot_user }}
+    - connection_pass: {{ dbroot_pass }}
+    {%- endif %}
     - require:
       - mysql_database: zabbix_db
       - mysql_user: zabbix_db


### PR DESCRIPTION
This fixes #52 by allowing alternative credentials to be provided (e.g. Amazon RDS)