### PR TITLE
Initial selinux handling

### DIFF
--- a/zabbix/agent/init.sls
+++ b/zabbix/agent/init.sls
@@ -1,5 +1,8 @@
 {% from "zabbix/map.jinja" import zabbix with context -%}
 
+include:
+  - zabbix.users
+
 zabbix-agent-logdir:
   file.directory:
     - name: {{ salt['file.dirname'](zabbix.agent.logfile) }}
@@ -13,6 +16,38 @@ zabbix-agent-piddir:
     - user: {{ zabbix.user }}
     - group: {{ zabbix.group }}
     - dirmode: 750
+
+{% if salt['grains.get']('selinux:enforced', False) == 'Enforcing' %}
+/root/zabbix_agent.te:
+  file.managed:
+    - source: salt://zabbix/files/default/tmp/zabbix_agent.te
+
+generate_agent_mod:
+  cmd.run:
+    - name: checkmodule -M -m -o zabbix_agent.mod zabbix_agent.te
+    - cwd: /root
+    - onchanges:
+      - file: /root/zabbix_agent.te
+
+generate_agent_pp:
+  cmd.run:
+    - name: semodule_package -o zabbix_agent.pp -m zabbix_agent.mod
+    - cwd: /root
+    - onchanges:
+      - cmd: generate_agent_mod
+
+set_agent_policy:
+  cmd.run:
+    - name: semodule -i zabbix_agent.pp
+    - cwd: /root
+    - onchanges:
+      - cmd: generate_agent_pp
+
+enable_selinux_agent:
+  selinux.module:
+    - name: zabbix_agent
+    - module_state: enabled
+{% endif %}
 
 zabbix-agent:
   pkg.installed:
@@ -28,3 +63,4 @@ zabbix-agent:
     - enable: True
     - require:
       - pkg: zabbix-agent
+

--- a/zabbix/files/default/tmp/zabbix_agent.te
+++ b/zabbix/files/default/tmp/zabbix_agent.te
@@ -1,0 +1,10 @@
+
+module zabbix_agent 1.0;
+
+require {
+       	type zabbix_agent_t;
+       	class process setrlimit;
+}
+
+#============= zabbix_agent_t ==============
+allow zabbix_agent_t self:process setrlimit;

--- a/zabbix/files/default/tmp/zabbix_server.te
+++ b/zabbix/files/default/tmp/zabbix_server.te
@@ -1,0 +1,10 @@
+
+module zabbix_server 1.0;
+
+require {
+       	type zabbix_t;
+       	class process setrlimit;
+}
+
+#============= zabbix_t ==============
+allow zabbix_t self:process setrlimit;

--- a/zabbix/server/init.sls
+++ b/zabbix/server/init.sls
@@ -15,6 +15,38 @@ zabbix-server-piddir:
     - group: {{ zabbix.group }}
     - dirmode: 755
 
+{% if salt['grains.get']('selinux:enforced', False) == 'Enforcing' %}
+/root/zabbix_server.te:
+  file.managed:
+    - source: salt://zabbix/files/default/tmp/zabbix_server.te
+
+generate_server_mod:
+  cmd.run:
+    - name: checkmodule -M -m -o zabbix_server.mod zabbix_server.te
+    - cwd: /root
+    - onchanges:
+      - file: /root/zabbix_server.te
+
+generate_server_pp:
+  cmd.run:
+    - name: semodule_package -o zabbix_server.pp -m zabbix_server.mod
+    - cwd: /root
+    - onchanges:
+      - cmd: generate_server_mod
+
+set_server_policy:
+  cmd.run:
+    - name: semodule -i zabbix_server.pp
+    - cwd: /root
+    - onchanges:
+      - cmd: generate_server_pp
+
+enable_selinux_server:
+  selinux.module:
+    - name: zabbix_server
+    - module_state: enabled
+{% endif %}
+
 zabbix-server:
   pkg.installed:
     - pkgs:


### PR DESCRIPTION
Allows the server and agent to start when run in selinux enforcing mode. Likely the server will require additional selinux perms in order to listen to a network socket. 