### PR TITLE
Use new mysql file import functionality

### DIFF
--- a/zabbix/mysql/conf.sls
+++ b/zabbix/mysql/conf.sls
@@ -1,16 +1,11 @@
-{% from "zabbix/map.jinja" import zabbix with context -%}
-{% set settings = salt['pillar.get']('zabbix-mysql', {}) -%}
-{% set dbhost = settings.get('dbhost', 'localhost') -%}
-{% set dbname = settings.get('dbname', 'zabbix') -%}
-{% set dbuser = settings.get('dbuser', 'zabbixuser') -%}
-{% set dbpass = settings.get('dbpass', 'zabbixpass') -%}
-{% set dbuser_host = settings.get('dbuser_host', 'localhost') -%}
-
+{% set dbname = salt['pillar.get']('zabbix-server:dbname', 'zabbix') -%}
+{% set dbuser = salt['pillar.get']('zabbix-server:dbuser', 'zabbixuser') -%}
+{% set dbpass = salt['pillar.get']('zabbix-server:dbpass', 'zabbixpass') -%}
+{% set dbuser_host = salt['pillar.get']('zabbix-server:dbuser_host', 'localhost') -%}
 
 zabbix_db:
   mysql_database.present:
     - name: {{ dbname }}
-    - host: {{ dbhost }}
     - character_set: utf8
     - collate: utf8_bin
   mysql_grants.present:


### PR DESCRIPTION
... added to salt in Nitrogen saltstack/salt#38561
Salt installs before Nitrogen can make use of the new functionality by copying the updated mysql state and module from the develop branch to _states and _modules. 

This allows for mysql data import without having to shell out and rely on the mysql binary. This simplifies zabbix installs as mysql package names differ on various distros.

Mysql connection handling relies on configuring the mysql module. A zabbix pillar might look something like:
```
mysql.host: some.host.com
mysql.user: 'admin'
mysql.pass: super-secret-password

zabbix-server:
  dbhost: some.host.com
  dbname: zabbix_db
  dbuser: zabbix_user
  dbpass: secret-zabbix-db-user-pass
  dbuser_host: zabbix.server.ip
```

