### PR TITLE
Fix zabbix user/group creation issues

### DIFF
--- a/zabbix/agent/conf.sls
+++ b/zabbix/agent/conf.sls
@@ -4,6 +4,7 @@
 
 include:
   - zabbix.agent
+  - zabbix.users
 
 
 {{ zabbix.agent.config }}:
@@ -14,5 +15,6 @@ include:
     - template: jinja
     - require:
       - pkg: zabbix-agent
+      - user: zabbix_user
     - watch_in:
       - service: zabbix-agent

--- a/zabbix/agent/init.sls
+++ b/zabbix/agent/init.sls
@@ -1,7 +1,21 @@
 {% from "zabbix/map.jinja" import zabbix with context -%}
 
-include:
-  - zabbix.users
+zabbix-agent:
+  pkg.installed:
+    - pkgs:
+      {%- for name in zabbix.agent.pkgs %}
+      - {{ name }}
+      {%- endfor %}
+    {%- if zabbix.agent.version is defined %}
+    - version: {{ zabbix.agent.version }}
+    {%- endif %}
+  service.running:
+    - name: {{ zabbix.agent.service }}
+    - enable: True
+    - require:
+      - pkg: zabbix-agent
+      - zabbix-agent-logdir
+      - zabbix-agent-piddir
 
 zabbix-agent-logdir:
   file.directory:
@@ -17,17 +31,3 @@ zabbix-agent-piddir:
     - group: {{ zabbix.group }}
     - dirmode: 750
 
-zabbix-agent:
-  pkg.installed:
-    - pkgs:
-      {%- for name in zabbix.agent.pkgs %}
-      - {{ name }}
-      {%- endfor %}
-    {%- if zabbix.agent.version is defined %}
-    - version: {{ zabbix.agent.version }}
-    {%- endif %}
-  service.running:
-    - name: {{ zabbix.agent.service }}
-    - enable: True
-    - require:
-      - pkg: zabbix-agent

--- a/zabbix/users.sls
+++ b/zabbix/users.sls
@@ -18,3 +18,4 @@ zabbix_user:
 zabbix_group:
   group.present:
     - name: {{ zabbix.group }}
+    - system: True


### PR DESCRIPTION
Hello maintainers! 

The way the 'zabbix' user is created was changed [recently](https://github.com/saltstack-formulas/zabbix-formula/commit/e3e487e6ac233f8ed902d242141d4c316ab5527d).  I observed that on my Ubuntu (Xenial and Trusty) boxes & VMs, I would previously get a user with uid/gid in the low 100's, whereas I now end-up with a UID around 999 and GID of 1001 (+/- a few units).  This changed behaviour is a little unpleasant per se because it makes for discrepancies between machines but we'll leave the fix to this for the second commit because it's perhaps a little more subjective.

This first commit addresses the part which is almost certainly incorrect, namely that the UID of the created user is in the "system" range, whereas the GID isn't.