### PR TITLE
Set 'default' as base in OS map

### DIFF
--- a/zabbix/map.jinja
+++ b/zabbix/map.jinja
@@ -153,4 +153,4 @@
       'logfile': '/var/log/zabbix/zabbix_proxy.log'
     }
   },
-}, merge=salt['pillar.get']('zabbix:lookup')) %}
+}, merge=salt['pillar.get']('zabbix:lookup'), base='default') %}


### PR DESCRIPTION
This PR can be considered as as hotfix for #71.
#72 revealed (for me) serious flaw in my recent changes - #71 by default OS specific dict does not merge with 'default' dict, but just replace it. So if OS dict does not contain some key it will be unset, I think it's better that it will be set to default value. After all, the default values are created for this, to substitute what is missed.
Also this approach described in [template-formula](https://github.com/saltstack-formulas/template-formula/blob/5238913d6cb40ba4143963807e3c975144c7b8f4/template/map.jinja#L8)

This PR is important because after #71 all zabbix-agent defaults are stored in map.jinja and currently they only present for Debian. So zabbix_agent.conf will be generated improperly for all OS except Debian.

After this change OS dict will be merged with 'default' and than 'zabbix:lookup' pillar will be merged over again.

Pros of this PR: #71 will work as intended.
Cons of this PR: OS dict will be populated with keys which was unset before, I can't see why this can break anything, but may be I'm missing something.

@landergate please considered to review this change.