### PR TITLE
Fix agent not restarting when needed

### DIFF
--- a/zabbix/agent/conf.sls
+++ b/zabbix/agent/conf.sls
@@ -17,4 +17,4 @@ include:
       - pkg: zabbix-agent
       - user: zabbix_user
     - watch_in:
-      - service: zabbix-agent
+      - module: zabbix-agent-restart

--- a/zabbix/agent/init.sls
+++ b/zabbix/agent/init.sls
@@ -66,3 +66,7 @@ zabbix-agent:
       - file: zabbix-agent-logdir
       - file: zabbix-agent-piddir
 
+zabbix-agent-restart:
+  module.wait:
+    - name: service.restart
+    - m_name: {{ zabbix.agent.service }}


### PR DESCRIPTION
On the first run, when the service is already started by the package installation, the formula fails to restart the agent saying that agent is already running and enabled.

This approach is similar to what apache-formula uses and it forces the agent to be restarted whenever the config changes.
https://github.com/saltstack-formulas/apache-formula/blob/master/apache/init.sls#L38