### PR TITLE
Fix requisite ID in zabbix.agent.conf introduced by #10

### DIFF
--- a/zabbix/agent/conf.sls
+++ b/zabbix/agent/conf.sls
@@ -15,6 +15,6 @@ include:
     - template: jinja
     - require:
       - pkg: zabbix-agent
-      - user: zabbix_user
+      - user: zabbix-formula_zabbix_user
     - watch_in:
       - module: zabbix-agent-restart


### PR DESCRIPTION
After merging #10 `zabbix.agent.conf` became nonfunctional, this PR fixes it.