### PR TITLE
Add SELinux policies for Zabbix 3.4 and SELinux booleans for httpd

### DIFF
--- a/zabbix/files/default/tmp/zabbix_server_34.te
+++ b/zabbix/files/default/tmp/zabbix_server_34.te
@@ -1,0 +1,25 @@
+
+module zabbix_server_34 1.1;
+
+require {
+        type zabbix_var_run_t;
+        type tmp_t;
+        type zabbix_t;
+        class sock_file { create unlink write };
+        class unix_stream_socket connectto;
+        class process setrlimit;
+}
+
+#============= zabbix_t ==============
+
+#!!!! This avc is allowed in the current policy
+allow zabbix_t self:process setrlimit;
+
+#!!!! This avc is allowed in the current policy
+allow zabbix_t self:unix_stream_socket connectto;
+
+#!!!! This avc is allowed in the current policy
+allow zabbix_t tmp_t:sock_file { create unlink write };
+
+#!!!! This avc is allowed in the current policy
+allow zabbix_t zabbix_var_run_t:sock_file { create unlink write };

--- a/zabbix/frontend/init.sls
+++ b/zabbix/frontend/init.sls
@@ -10,3 +10,15 @@ zabbix-frontend-php:
     {% if zabbix.frontend.version is defined -%}
     - version: {{ zabbix.frontend.version }}
     {%- endif %}
+
+{% if salt['grains.get']('selinux:enforced', False) == 'Enforcing' %}
+httpd_can_connect_zabbix:
+  selinux.boolean:
+    - value: True
+    - persist: True
+
+httpd_can_network_connect:
+  selinux.boolean:
+    - value: True
+    - persist: True
+{% endif %}

--- a/zabbix/server/init.sls
+++ b/zabbix/server/init.sls
@@ -45,6 +45,39 @@ enable_selinux_server:
   selinux.module:
     - name: zabbix_server
     - module_state: enabled
+
+{% if zabbix.version_repo|float >= 3.4 -%}
+/root/zabbix_server_34.te:
+  file.managed:
+    - source: salt://zabbix/files/default/tmp/zabbix_server_34.te
+
+generate_server_34_mod:
+  cmd.run:
+    - name: checkmodule -M -m -o zabbix_server_34.mod zabbix_server_34.te
+    - cwd: /root
+    - onchanges:
+      - file: /root/zabbix_server_34.te
+
+generate_server_34_pp:
+  cmd.run:
+    - name: semodule_package -o zabbix_server_34.pp -m zabbix_server_34.mod
+    - cwd: /root
+    - onchanges:
+      - cmd: generate_server_mod
+
+set_server_policy_34:
+  cmd.run:
+    - name: semodule -i zabbix_server_34.pp
+    - cwd: /root
+    - onchanges:
+      - cmd: generate_server_pp
+
+enable_selinux_server_34:
+  selinux.module:
+    - name: zabbix_server_34
+    - module_state: enabled
+{% endif -%}
+
 {% endif %}
 
 zabbix-server:


### PR DESCRIPTION
Zabbix 3.4 requires additional SELinux policies due to the introduction of inter-process communication using sockets.  This commit also enables the booleans to allow httpd (apache or nginx) to connect to zabbix and connect to the network.  If there are more secure settings that should be used instead of the booleans, I'd be glad to have the input.