### PR TITLE
Improvements for zabbix.frontend state

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -67,7 +67,7 @@ zabbix-frontend:
   dbhost: localhost
   dbname: zabbix
   dbuser: zabbixuser
-  dbpass: zabbixpass
+  dbpassword: zabbixpass
   zbxserver: localhost
   zbxserverport: 10051
   zbxservername: 'Zabbix installed with saltstack'

--- a/zabbix/files/default/etc/zabbix/web/zabbix.conf.php.jinja
+++ b/zabbix/files/default/etc/zabbix/web/zabbix.conf.php.jinja
@@ -1,20 +1,26 @@
+{% from "zabbix/map.jinja" import zabbix with context -%}
 {% set settings = salt['pillar.get']('zabbix-frontend', {}) -%}
+{% set defaults = zabbix.get('frontend', {}) -%}
+{# This required for backward compatibility -#}
+{% if 'dbpass' in settings -%}
+{%  do settings.update({'dbpassword': settings['dbpass']}) -%}
+{% endif -%}
 <?php
 // Zabbix GUI configuration file
 global $DB;
 
-$DB["TYPE"]				= '{{ settings.get('dbtype', 'MYSQL') }}';
-$DB["SERVER"]			= '{{ settings.get('dbhost', 'localhost') }}';
+$DB["TYPE"]				= '{{ settings.get('dbtype', defaults.dbtype) }}';
+$DB["SERVER"]			= '{{ settings.get('dbhost', defaults.dbhost) }}';
 $DB["PORT"]				= '0';
-$DB["DATABASE"]			= '{{ settings.get('dbname', 'zabbix') }}';
-$DB["USER"]				= '{{ settings.get('dbuser', 'zabbixuser') }}';
-$DB["PASSWORD"]			= '{{ settings.get('dbpass', 'zabbixpass') }}';
+$DB["DATABASE"]			= '{{ settings.get('dbname', defaults.dbname) }}';
+$DB["USER"]				= '{{ settings.get('dbuser', defaults.dbuser) }}';
+$DB["PASSWORD"]			= '{{ settings.get('dbpassword', defaults.dbpassword) }}';
 // SCHEMA is relevant only for IBM_DB2 database
 $DB["SCHEMA"]			= '';
 
-$ZBX_SERVER				= '{{ settings.get('zbxserver', 'localhost') }}';
-$ZBX_SERVER_PORT		= '{{ settings.get('zbxserverport', '10051') }}';
-$ZBX_SERVER_NAME		= '{{ settings.get('zbxservername', 'Zabbix installed with saltstack') }}';
+$ZBX_SERVER				= '{{ settings.get('zbxserver', defaults.zbxserver) }}';
+$ZBX_SERVER_PORT		= '{{ settings.get('zbxserverport', defaults.zbxserverport) }}';
+$ZBX_SERVER_NAME		= '{{ settings.get('zbxservername', defaults.zbxservername) }}';
 
 $IMAGE_FORMAT_DEFAULT	= IMAGE_FORMAT_PNG;
 ?>

--- a/zabbix/frontend/conf.sls
+++ b/zabbix/frontend/conf.sls
@@ -1,5 +1,7 @@
 {% from "zabbix/map.jinja" import zabbix with context -%}
 {% from "zabbix/macros.jinja" import files_switch with context -%}
+{% set config_file = salt.file.basename(zabbix.frontend.config) -%}
+{% set config_file_dir = salt.file.dirname(zabbix.frontend.config) -%}
 
 
 include:
@@ -10,16 +12,18 @@ include:
 {{ zabbix.frontend.config }}:
   file.managed:
     - source: {{ files_switch('zabbix',
-                              ['/etc/zabbix/web/zabbix.conf.php',
-                               '/etc/zabbix/web/zabbix.conf.php.jinja']) }}
+                              [zabbix.frontend.config,
+                               zabbix.frontend.config ~ '.jinja',
+                               '/etc/zabbix/web/' ~ config_file,
+                               '/etc/zabbix/web/' ~ config_file ~ '.jinja']) }}
     - template: jinja
     - require:
       - pkg: zabbix-frontend-php
-      - file: /etc/zabbix/web
+      - file: {{ config_file_dir }}
 
 
-# Fix permissions to allow to php-fpm include /etc/zabbix/web/*
-/etc/zabbix/web:
+# Fix permissions to allow to php-fpm include zabbix frontend config file which is usually located under /etc/zabbix
+{{ config_file_dir }}:
   file.directory:
     - mode: 755
     - require:

--- a/zabbix/map.jinja
+++ b/zabbix/map.jinja
@@ -173,7 +173,15 @@
     },
     'frontend': {
       'pkgs': ['zabbix-web-mysql'],
-      'config': '/etc/zabbix/web/zabbix.conf.php'
+      'config': '/etc/zabbix/web/zabbix.conf.php',
+      'dbtype': 'MYSQL',
+      'dbhost': 'localhost',
+      'dbname': 'zabbix',
+      'dbuser': 'zabbix',
+      'dbpassword': 'zabbix',
+      'zbxserver': 'localhost',
+      'zbxserverport': '10051',
+      'zbxservername': 'Zabbix installed with SaltStack'
     },
     'proxy': {
       'pkgs': ['zabbix-proxy-sqlite3', 'zabbix-get'],


### PR DESCRIPTION
- Defaults moved to map.jinja
- More flexible states for frontend configuration file.
New version handle conditions when configuration file location different from `/etc/zabbix/web`. I.e. since version 3.0 default location is `/etc/zabbix`.
- 'dbpass' chaged to 'dbpassword', compatibility preserved.