### PR TITLE
Let package manager create user, group and directories

### DIFF
--- a/zabbix/agent/conf.sls
+++ b/zabbix/agent/conf.sls
@@ -4,7 +4,6 @@
 
 include:
   - zabbix.agent
-  - zabbix.users
 
 
 {{ zabbix.agent.config }}:
@@ -15,6 +14,5 @@ include:
     - template: jinja
     - require:
       - pkg: zabbix-agent
-      - user: zabbix-formula_zabbix_user
     - watch_in:
       - module: zabbix-agent-restart

--- a/zabbix/frontend/conf.sls
+++ b/zabbix/frontend/conf.sls
@@ -6,7 +6,6 @@
 
 include:
   - zabbix.frontend
-  - zabbix.frontend.repo
 
 
 {{ zabbix.frontend.config }}:
@@ -36,10 +35,8 @@ zabbix-frontend_debconf:
   debconf.set:
     - name: zabbix-frontend-php
     - data:
-        'zabbix-frontend-php/configure-apache': {'type': 'boolean',
-                                                 'value': False}
-        'zabbix-frontend-php/restart-webserver': {'type': 'boolean',
-                                                  'value': False}
+        'zabbix-frontend-php/configure-apache': {'type': 'boolean', 'value': False}
+        'zabbix-frontend-php/restart-webserver': {'type': 'boolean', 'value': False}
     - prereq:
       - pkg: zabbix-frontend-php
 {%- endif %}

--- a/zabbix/frontend/init.sls
+++ b/zabbix/frontend/init.sls
@@ -1,6 +1,5 @@
 {% from "zabbix/map.jinja" import zabbix with context -%}
 
-
 zabbix-frontend-php:
   pkg.installed:
     - pkgs:

--- a/zabbix/proxy/conf.sls
+++ b/zabbix/proxy/conf.sls
@@ -4,7 +4,6 @@
 
 include:
   - zabbix.proxy
-  - zabbix.users
 
 
 {{ zabbix.proxy.config }}:

--- a/zabbix/server/conf.sls
+++ b/zabbix/server/conf.sls
@@ -4,7 +4,6 @@
 
 include:
   - zabbix.server
-  - zabbix.users
 
 
 {{ zabbix.server.config }}:


### PR DESCRIPTION
Create them manually as fallback.

- Order states in more logical manner
- More permanent code style
- 'settings' variable removed from zabbix.server and zabbix.proxy it is not used anywhere later in code.