### PR TITLE
Clean zabbix.list file before switching to another version

### DIFF
--- a/zabbix/repo.sls
+++ b/zabbix/repo.sls
@@ -26,7 +26,7 @@
     - name: deb http://repo.zabbix.com/zabbix/{{ zabbix.version_repo }}/{{ salt['grains.get']('os')|lower }} {{ salt['grains.get']('oscodename') }} main
     - file: /etc/apt/sources.list.d/zabbix.list
     - key_url: https://repo.zabbix.com/zabbix-official-repo.key
-
+    - clean_file: True
 
 {%- elif salt['grains.get']('os_family') == 'RedHat' and
          salt['grains.get']('osmajorrelease')|int >= 6 %}


### PR DESCRIPTION
If file will not be cleaned you'll end up with something like this:
```
deb http://repo.zabbix.com/zabbix/3.0/debian stretch main
deb-src http://repo.zabbix.com/zabbix/3.0/debian stretch main
deb http://repo.zabbix.com/zabbix/3.4/debian stretch main
deb-src http://repo.zabbix.com/zabbix/3.4/debian stretch main
```

- In case of upgrade there is no reason to preserve repo for old version.
- In case of downgrade you will be forced to specify version for every installed zabbix package like that:
```yaml
zabbix:
  lookup:
    version_repo: '2.4'
    server:
      version: '2.4.*'
    agent:
      version: '2.4.*'
```
but usually you just need to install latest available version.
- I think preserving old repo lines is not what you expect when you change repo version in formula.