### PR TITLE
Fixed version support for zabbix packages

### DIFF
--- a/zabbix/agent/init.sls
+++ b/zabbix/agent/init.sls
@@ -7,11 +7,8 @@ zabbix-agent:
   pkg.installed:
     - pkgs:
       {%- for name in zabbix.agent.pkgs %}
-      - {{ name }}
+      - {{ name }}{% if zabbix.agent.version is defined and 'zabbix' in name %}: '{{ zabbix.agent.version }}'{% endif %}
       {%- endfor %}
-    {%- if zabbix.agent.version is defined %}
-    - version: {{ zabbix.agent.version }}
-    {%- endif %}
     - require_in:
       - user: zabbix-formula_zabbix_user
       - group: zabbix-formula_zabbix_group

--- a/zabbix/frontend/init.sls
+++ b/zabbix/frontend/init.sls
@@ -4,11 +4,8 @@ zabbix-frontend-php:
   pkg.installed:
     - pkgs:
       {%- for name in zabbix.frontend.pkgs %}
-      - {{ name }}
+      - {{ name }}{% if zabbix.frontend.version is defined and 'zabbix' in name %}: '{{ zabbix.frontend.version }}'{% endif %}
       {%- endfor %}
-    {% if zabbix.frontend.version is defined -%}
-    - version: {{ zabbix.frontend.version }}
-    {%- endif %}
 
 {% if salt['grains.get']('selinux:enforced', False) == 'Enforcing' %}
 httpd_can_connect_zabbix:

--- a/zabbix/proxy/init.sls
+++ b/zabbix/proxy/init.sls
@@ -7,11 +7,8 @@ zabbix-proxy:
   pkg.installed:
     - pkgs:
       {%- for name in zabbix.proxy.pkgs %}
-      - {{ name }}
+      - {{ name }}{% if zabbix.proxy.version is defined and 'zabbix' in name %}: '{{ zabbix.proxy.version }}'{% endif %}
       {%- endfor %}
-    {%- if zabbix.proxy.version is defined -%}
-    - version: {{ zabbix.proxy.version }}
-    {%- endif %}
     - require_in:
       - user: zabbix-formula_zabbix_user
       - group: zabbix-formula_zabbix_group

--- a/zabbix/server/init.sls
+++ b/zabbix/server/init.sls
@@ -7,11 +7,8 @@ zabbix-server:
   pkg.installed:
     - pkgs:
       {%- for name in zabbix.server.pkgs %}
-      - {{ name }}
+      - {{ name }}{% if zabbix.server.version is defined and 'zabbix' in name %}: '{{ zabbix.server.version }}'{% endif %}
       {%- endfor %}
-    {%- if zabbix.server.version is defined %}
-    - version: {{ zabbix.server.version }}
-    {%- endif %}
     {% if salt['grains.get']('os_family') == 'Debian' -%}
     - install_recommends: False
     {% endif %}


### PR DESCRIPTION
Currently specifying version in lookup pillar does not work at all, because `pkg.installed` parameter `version` does not work if multiple packages supplied via `pkgs` parameter.
This PR fixes this bug.