### PR TITLE
Add PostgreSQL support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -143,6 +143,16 @@ Creates database and mysql user for Zabbix.
 
 Creates mysql schema for Zabbix.
 
+``zabbix.pgsql.conf``
+----------------
+
+Creates database and PostgreSQL user for Zabbix.
+
+``zabbix.pgsql.schema``
+---------------------
+
+Creates PostgreSQL schema for Zabbix.
+
 ``zabbix.repo``
 ----------------
 

--- a/pillar.example
+++ b/pillar.example
@@ -88,3 +88,28 @@ zabbix-proxy:
   dbname: /var/lib/zabbix/zabbix_proxy.db
   dbuser: zabbix
   include: /etc/zabbix/zabbix_proxy.d/
+
+# Example with PostgreSQL on Debian 9
+# Installation with PostgreSQL will likely not work with Zabbix version below 3.0
+zabbix:
+  lookup:
+    version_repo: 3.4
+    agent:
+      version: '1:3.4.*'
+    frontend:
+      version: '1:3.4.*'
+      dbtype: POSTGRESQL
+    # you need to override default package list
+    server:
+      version: '1:3.4.*'
+      pkgs:
+        - zabbix-server-pgsql
+        - zabbix-get
+      # unset dbsocket, it's not used with PostgreSQL
+      dbsocket: ""
+
+zabbix-pgsql:
+  # By default SQL dump provided by Zabbix package will be used, but you can
+  # put your own dump in corresponding directory (consult with TOFS_pattern.md)
+  # and specify path in sql_file param
+  sql_file: /usr/share/doc/zabbix-server-pgsql/custom.sql.gz

--- a/zabbix/map.jinja
+++ b/zabbix/map.jinja
@@ -51,6 +51,9 @@
     },
     'mysql': {
       'pkgs': ['python-mysqldb']
+    },
+    'pgsql': {
+      'pkgs': ['postgresql-client-common', 'postgresql-client']
     }
   },
 
@@ -204,6 +207,13 @@
       'dbuser': 'zabbix',
       'dbpassword': 'zabbix',
       'dbuser_host': 'localhost'
+    },
+    'pgsql': {
+      'skip_pkgs': false,
+      'dbhost': 'localhost',
+      'dbname': 'zabbix',
+      'dbuser': 'zabbix',
+      'dbpassword': 'zabbix'
     }
   },
 }, merge=salt['pillar.get']('zabbix:lookup'), base='default') %}

--- a/zabbix/pgsql/conf.sls
+++ b/zabbix/pgsql/conf.sls
@@ -1,0 +1,69 @@
+{% from "zabbix/map.jinja" import zabbix with context -%}
+{% set settings = salt['pillar.get']('zabbix-pgsql', {}) -%}
+{% set defaults = zabbix.get('pgsql', {}) -%}
+
+{% set dbhost = settings.get('dbhost', defaults.dbhost) -%}
+{% set dbname = settings.get('dbname', defaults.dbname) -%}
+{% set dbuser = settings.get('dbuser', defaults.dbuser) -%}
+{% set dbpassword = settings.get('dbpassword', defaults.dbpassword) -%}
+
+{% set dbroot_user = settings.get('dbroot_user') -%}
+{% set dbroot_pass = settings.get('dbroot_pass') -%}
+
+# Install packages required for Salt postgres module
+{% if settings.get('pkgs', defaults.get('pkgs', False))
+      and not settings.get('skip_pkgs', defaults.skip_pkgs) -%}
+pgsql_packages:
+  pkg.installed:
+    - pkgs: {{ settings.get('pkgs', defaults.pkgs)|json }}
+{% elif settings.get('skip_pkgs', defaults.skip_pkgs) -%}
+pgsql_packages:
+  test.configurable_test_state:
+    - name: You skipped installation of packages required for Salt postgres module.
+    - changes: False
+    - result: True
+{% else -%}
+pgsql_packages:
+  test.configurable_test_state:
+    - name: Packages required for Salt postgres module are not defined
+    - changes: False
+    - result: False
+    - comment: |
+        Additional packages are required to manage the PostgreSQL database.
+        Please specify them in pillar as list.
+        Tip: you need postgresql-client packages, like:
+        zabbix-pgsql:
+          pkgs:
+            - postgresql-client-common
+            - postgresql-client
+        Or you can skip installing them, but formula likely fail without them.
+        zabbix-pgsql:
+          skip_pkgs: True
+{% endif -%}
+
+zabbix_pgsql_user:
+  postgres_user.present:
+    - name: {{ dbuser }}
+    - password: {{ dbpassword }}
+    - encrypted: True
+    - login: True
+    {%- if dbroot_user and dbroot_pass %}
+    - db_host: {{ dbhost }}
+    - db_user: {{ dbroot_user }}
+    - db_password: {{ dbroot_pass }}
+    {%- endif %}
+    - require:
+      - pgsql_packages
+
+zabbix_pgsql_db:
+  postgres_database.present:
+    - name: {{ dbname }}
+    - owner: {{ dbuser }}
+    {%- if dbroot_user and dbroot_pass %}
+    - db_host: {{ dbhost }}
+    - db_user: {{ dbroot_user }}
+    - db_password: {{ dbroot_pass }}
+    {%- endif %}
+    - require:
+      - pgsql_packages
+      - postgres_user: zabbix_pgsql_user

--- a/zabbix/pgsql/schema.sls
+++ b/zabbix/pgsql/schema.sls
@@ -1,0 +1,61 @@
+{% from "zabbix/map.jinja" import zabbix with context -%}
+{% from "zabbix/macros.jinja" import files_switch with context -%}
+{% set settings = salt['pillar.get']('zabbix-pgsql', {}) -%}
+{% set defaults = zabbix.get('pgsql', {}) -%}
+
+{% set dbhost = settings.get('dbhost', defaults.dbhost) -%}
+{% set dbname = settings.get('dbname', defaults.dbname) -%}
+{% set dbuser = settings.get('dbuser', defaults.dbuser) -%}
+{% set dbpassword = settings.get('dbpassword', defaults.dbpassword) -%}
+
+{% set dbroot_user = settings.get('dbroot_user') -%}
+{% set dbroot_pass = settings.get('dbroot_pass') -%}
+
+{% set sql_file = settings.get('sql_file', '/usr/share/doc/zabbix-server-pgsql/create.sql.gz') -%}
+
+# Connection args required only if dbroot_user and dbroot_pass defined.
+{% set connection_args = {} -%}
+{% if dbroot_user and dbroot_pass -%}
+{%  set connection_args = {'runas': 'nobody', 'host': dbhost, 'user': dbroot_user, 'password': dbroot_pass} -%}
+{% endif -%}
+
+# Check is there any tables in database.
+# salt.postgres.psql_query return empty result if there is no tables or 'False' on any error i.e. failed auth.
+{% set list_tables = "SELECT tablename FROM pg_catalog.pg_tables WHERE schemaname != 'pg_catalog' AND schemaname != 'information_schema' LIMIT 1;" %}
+{% set is_db_empty = True -%}
+{% if salt.postgres.psql_query(query=list_tables, maintenance_db=dbname, **connection_args) -%}
+{%  set is_db_empty = False -%}
+{% endif -%}
+
+include:
+  - zabbix.pgsql.conf
+
+check_db_pgsql:
+  test.configurable_test_state:
+    - name: Is there any tables in '{{ dbname }}' database?
+    - changes: {{ is_db_empty }}
+    - result: True
+    - comment: If changes is 'True' data import required.
+
+{% if 'sql_file' in settings -%}
+upload_sql_dump:
+  file.managed:
+    - makedirs: True
+    - source: {{ files_switch('zabbix', [ sql_file ]) }}
+    - require_in:
+      - import_sql
+{% endif -%}
+
+import_sql:
+  cmd.run:
+    - name: zcat {{ sql_file }} | psql | head -5
+    - runas: {{ zabbix.user }}
+    - env:
+      - PGUSER: {{ dbuser }}
+      - PGPASSWORD: {{ dbpassword }}
+      - PGDATABASE: {{ dbname }}
+      - PGHOST: {{ dbhost }}
+    - require:
+      - pkg: zabbix-server
+    - onchanges:
+      - test: check_db_pgsql

--- a/zabbix/server/conf.sls
+++ b/zabbix/server/conf.sls
@@ -24,7 +24,7 @@ include:
       - service: zabbix-server
 
 
-{% if salt['grains.get']('os_family') == 'Debian' -%}
+{% if salt['grains.get']('os_family') == 'Debian' and 'zabbix-server-mysql' in zabbix.server.pkgs -%}
 # We don't want to manage the db through dbconfig
 zabbix-server_debconf:
   debconf.set:


### PR DESCRIPTION
This PR add support of PostgreSQL version of Zabbix server to formula.
It's only tested with Zabbix version 3.4 but should work with 3.0+ and hopefully with upcoming v. 4 too. First of all I have no time to test and adapt for v. 2.0 - 2.2, and second I see no reason for that, I hope nobody will create new Zabbix installations with those old versions.

Main difference with MySQL part - instead of supply SQL schema with formula, SQL provided in package used.