### PR TITLE
Ignore non-existing groups

### DIFF
--- a/zabbix/users.sls
+++ b/zabbix/users.sls
@@ -6,7 +6,7 @@ zabbix-formula_zabbix_user:
   user.present:
     - name: {{ zabbix.user }}
     - gid: {{ zabbix.group }}
-    - groups: {{ settings.get('user_groups', []) }}
+    - optional_groups: {{ settings.get('user_groups', []) }}
     # Home directory should be created by pkg scripts
     - createhome: False
     - shell: {{ zabbix.shell }}


### PR DESCRIPTION
Make zabbix user group membership optional.

This allow the user to use the same pillar specification for servers running different services. E.g.:

zabbix:
  user_groups:
    - mysql
    - named
    - radiusd

The zabbix user will be added to the existing groups on each server and non-existing groups will be ignored.