### PR TITLE
Added complete management of include directories

### DIFF
--- a/zabbix/agent/init.sls
+++ b/zabbix/agent/init.sls
@@ -1,4 +1,6 @@
 {% from "zabbix/map.jinja" import zabbix with context -%}
+{% set settings = salt['pillar.get']('zabbix-agent', {}) -%}
+{% set defaults = zabbix.get('agent', {}) -%}
 
 include:
   - zabbix.users
@@ -42,6 +44,16 @@ zabbix-agent-piddir:
     - dirmode: 750
     - require:
       - pkg: zabbix-agent
+
+{% for include in settings.get('includes', defaults.includes) %}
+{{ include }}:
+  file.directory:
+    - user: {{ zabbix.user }}
+    - group: {{ zabbix.group }}
+    - dirmode: 750
+    - require:
+      - pkg: zabbix-agent
+{%- endfor %}
 
 {% if salt['grains.get']('selinux:enforced', False) == 'Enforcing' %}
 /root/zabbix_agent.te:

--- a/zabbix/files/default/etc/zabbix/zabbix_proxy.conf.jinja
+++ b/zabbix/files/default/etc/zabbix/zabbix_proxy.conf.jinja
@@ -414,7 +414,12 @@ StartJavaPollers={{ settings.get('startjavapollers') }}
 #	You may include individual files or all files in a directory in the configuration file.
 #	Installing Zabbix will create include directory in /usr/local/etc, unless modified during the compile time.
 #
-{% if settings.get('include', false) %}Include={{ settings.get('include') }}{% endif %}
+{% if 'include' in settings and settings['include'] is string -%}
+{% do settings.update({'includes': [settings['include']]}) -%}
+{% endif -%}
+{% for include in settings.get('includes', defaults.includes) %}
+Include={{ include }}
+{%- endfor %}
 
 {% if zabbix.version_repo|float >= 2.4 -%}
 ### Option: SSLCertLocation

--- a/zabbix/files/default/etc/zabbix/zabbix_proxy.conf.jinja
+++ b/zabbix/files/default/etc/zabbix/zabbix_proxy.conf.jinja
@@ -1,6 +1,6 @@
 {% from "zabbix/map.jinja" import zabbix with context -%}
 {% set settings = salt['pillar.get']('zabbix-proxy', {}) -%}
-{% set defaults = zabbix.get('agent', {}) -%}
+{% set defaults = zabbix.get('proxy', {}) -%}
 # Managed by saltstack
 # This is a configuration file for Zabbix Proxy process
 # To get more information about Zabbix,_# visit http://www.zabbix.com

--- a/zabbix/files/default/etc/zabbix/zabbix_proxy.conf.jinja
+++ b/zabbix/files/default/etc/zabbix/zabbix_proxy.conf.jinja
@@ -1,5 +1,6 @@
 {% from "zabbix/map.jinja" import zabbix with context -%}
 {% set settings = salt['pillar.get']('zabbix-proxy', {}) -%}
+{% set defaults = zabbix.get('agent', {}) -%}
 # Managed by saltstack
 # This is a configuration file for Zabbix Proxy process
 # To get more information about Zabbix,_# visit http://www.zabbix.com

--- a/zabbix/map.jinja
+++ b/zabbix/map.jinja
@@ -47,7 +47,8 @@
       'config': '/etc/zabbix/zabbix_proxy.conf',
       'dbname': '/var/lib/zabbix/zabbix_proxy.db',
       'pidfile': '/var/run/zabbix/zabbix_proxy.pid',
-      'logfile': '/var/log/zabbix/zabbix_proxy.log'
+      'logfile': '/var/log/zabbix/zabbix_proxy.log',
+      'includes': ['/etc/zabbix/zabbix_proxy.d/']
     },
     'mysql': {
       'pkgs': ['python-mysqldb']

--- a/zabbix/proxy/init.sls
+++ b/zabbix/proxy/init.sls
@@ -37,3 +37,12 @@ zabbix-proxy-piddir:
     - dirmode: 750
     - require:
       - pkg: zabbix-proxy
+
+zabbix-proxy-includesdir:
+  file.directory:
+    - name: {{ salt['file.dirname'](zabbix.proxy.includes) }}
+    - user: {{ zabbix.user }}
+    - group: {{ zabbix.group }}
+    - dirmode: 750
+    - require:
+      - pkg: zabbix-proxy

--- a/zabbix/proxy/init.sls
+++ b/zabbix/proxy/init.sls
@@ -1,4 +1,6 @@
 {% from "zabbix/map.jinja" import zabbix with context -%}
+{% set settings = salt['pillar.get']('zabbix-proxy', {}) -%}
+{% set defaults = zabbix.get('proxy', {}) -%}
 
 include:
   - zabbix.users
@@ -38,7 +40,8 @@ zabbix-proxy-piddir:
     - require:
       - pkg: zabbix-proxy
 
-zabbix-proxy-includesdir:
+{% for include in settings.get('includes', defaults.includes) %}
+{{ include }}:
   file.directory:
     - name: {{ salt['file.dirname'](zabbix.proxy.includes) }}
     - user: {{ zabbix.user }}
@@ -46,3 +49,4 @@ zabbix-proxy-includesdir:
     - dirmode: 750
     - require:
       - pkg: zabbix-proxy
+{%- endfor %}

--- a/zabbix/proxy/init.sls
+++ b/zabbix/proxy/init.sls
@@ -40,13 +40,9 @@ zabbix-proxy-piddir:
     - require:
       - pkg: zabbix-proxy
 
-{% if 'include' in settings and settings['include'] is string -%}
-{% do settings.update({'includes': [settings['include']]}) -%}
-{% endif -%}
 {% for include in settings.get('includes', defaults.includes) %}
 {{ include }}:
   file.directory:
-    - name: {{ salt['file.dirname'](zabbix.proxy.includes) }}
     - user: {{ zabbix.user }}
     - group: {{ zabbix.group }}
     - dirmode: 750

--- a/zabbix/proxy/init.sls
+++ b/zabbix/proxy/init.sls
@@ -40,6 +40,9 @@ zabbix-proxy-piddir:
     - require:
       - pkg: zabbix-proxy
 
+{% if 'include' in settings and settings['include'] is string -%}
+{% do settings.update({'includes': [settings['include']]}) -%}
+{% endif -%}
 {% for include in settings.get('includes', defaults.includes) %}
 {{ include }}:
   file.directory:


### PR DESCRIPTION
In the last few days a started working with saltstack to manage our 30+ Zabbix Proxys. I made heavy use of the official formula. 
In my deployment I make use of the include dirs in nearly every environment. So I was missing that feature from the official formula. The Agent map.jinja had a already a default include, but no managed dir. 
So I added a default include for the proxy, as I think that each debian config file should have a default include.
But more important I added a FOR-loop that creates file.directory for each include folder. 
I hope you like my additions!