### PR TITLE
Reworked jinja Template for Zabbix Proxy & Agent 4.0 LTS

### DIFF
--- a/zabbix/files/default/etc/zabbix/zabbix_agentd.conf.jinja
+++ b/zabbix/files/default/etc/zabbix/zabbix_agentd.conf.jinja
@@ -32,7 +32,7 @@ LogType={{ settings['logtype'] }}
 ### Option: LogFile
 #	Log file name for LogType 'file' parameter.
 #
-# Mandatory: no
+# Mandatory: yes, if LogType is set to file, otherwise no
 # Default:
 # LogFile=
 {% if settings.get('logtype', defaults.get('logtype', 'file')) == 'file' %}
@@ -73,7 +73,11 @@ LogFileSize={{ settings.get('logfilesize', defaults.logfilesize)|int }}
 {% endif -%}
 #
 # Mandatory: no
+{% if zabbix.version_repo|float >= 3.0 -%}
 # Range: 0-5
+{% else %}
+# Range: 0-4
+{% endif %}
 # Default:
 # DebugLevel=3
 {% if settings.get('debuglevel', defaults.get('debuglevel', False)) -%}
@@ -113,11 +117,14 @@ LogRemoteCommands={{ settings.get('logremotecommands', defaults.logremotecommand
 ##### Passive checks related
 
 ### Option: Server
-#	List of comma delimited IP addresses (or hostnames) of Zabbix servers.
+#	List of comma delimited IP addresses, optionally in CIDR notation, or DNS names of Zabbix servers and Zabbix proxies.
 #	Incoming connections will be accepted only from the hosts listed here.
-#	If IPv6 support is enabled then '127.0.0.1', '::127.0.0.1', '::ffff:127.0.0.1' are treated equally.
+#	If IPv6 support is enabled then '127.0.0.1', '::127.0.0.1', '::ffff:127.0.0.1' are treated equally
+#	and '::/0' will allow any IPv4 or IPv6 address.
+#	'0.0.0.0/0' can be used to allow any IPv4 address.
+#	Example: Server=127.0.0.1,192.168.1.0/24,::1,2001:db8::/32,zabbix.example.com
 #
-# Mandatory: no
+# Mandatory: yes, if StartAgents is not explicitly set to 0
 # Default:
 # Server=
 {% if settings.get('server', defaults.get('server', False)) %}
@@ -157,7 +164,7 @@ StartAgents={{ settings.get('startagents', defaults.startagents) }}
 ##### Active checks related
 
 ### Option: ServerActive
-#	List of comma delimited IP:port (or hostname:port) pairs of Zabbix servers for active checks.
+#	List of comma delimited IP:port (or DNS name:port) pairs of Zabbix servers and Zabbix proxies for active checks.
 #	If port is not specified, default port is used.
 #	IPv6 addresses must be enclosed in square brackets if port for that host is specified.
 #	If port is not specified, square brackets for IPv6 addresses are optional.
@@ -363,6 +370,7 @@ UserParameter={{ userparameter }}
 ### Option: LoadModulePath
 #	Full path to location of agent modules.
 #	Default depends on compilation options.
+#	To see the default path run command "zabbix_agentd --help".
 #
 # Mandatory: no
 # Default:

--- a/zabbix/files/default/etc/zabbix/zabbix_proxy.conf.jinja
+++ b/zabbix/files/default/etc/zabbix/zabbix_proxy.conf.jinja
@@ -2,35 +2,54 @@
 {% set settings = salt['pillar.get']('zabbix-proxy', {}) -%}
 {% set defaults = zabbix.get('proxy', {}) -%}
 # Managed by saltstack
-# This is a configuration file for Zabbix Proxy process
-# To get more information about Zabbix,_# visit http://www.zabbix.com
+# This is a configuration file for Zabbix proxy daemon
+# To get more information about Zabbix, visit http://www.zabbix.com
 
 ############ GENERAL PARAMETERS #################
 
 ### Option: ProxyMode
-#	Proxy operating mode
+#	Proxy operating mode.
 #	0 - proxy in the active mode
 #	1 - proxy in the passive mode
 #
+# Mandatory: no
+# Default:
+# ProxyMode=0
 {% if settings.get('proxymode', defaults.get('proxymode', False)) %}ProxyMode={{ settings.get('proxymode', defaults.proxymode) }}{% endif %}
 
 ### Option: Server
-#	IP address (or hostname) of Zabbix server.
-#	Active proxy will get configuration data from the server.
-#	For a proxy in the passive mode this parameter will be ignored.
+#	If ProxyMode is set to active mode:
+#		IP address or DNS name of Zabbix server to get configuration data from and send data to.
+#	If ProxyMode is set to passive mode:
+#		List of comma delimited IP addresses, optionally in CIDR notation, or DNS names of Zabbix server.
+#		Incoming connections will be accepted only from the addresses listed here.
+#		If IPv6 support is enabled then '127.0.0.1', '::127.0.0.1', '::ffff:127.0.0.1' are treated equally
+#		and '::/0' will allow any IPv4 or IPv6 address.
+#		'0.0.0.0/0' can be used to allow any IPv4 address.
+#		Example: Server=127.0.0.1,192.168.1.0/24,::1,2001:db8::/32,zabbix.example.com
 #
+# Mandatory: yes
+# Default:
+# Server=
 {% if settings.get('server', defaults.get('server', False)) %}Server={{ settings.get('server', defaults.server) }}{% endif %}
 
 ### Option: ServerPort
 #	Port of Zabbix trapper on Zabbix server.
 #	For a proxy in the passive mode this parameter will be ignored.
 #
+# Mandatory: no
+# Range: 1024-32767
+# Default:
+# ServerPort=10051
 {% if settings.get('serverport', defaults.get('serverport', False)) %}ServerPort={{ settings.get('serverport', defaults.serverport) }}{% endif %}
 
 ### Option: Hostname
 #	Unique, case sensitive Proxy name. Make sure the Proxy name is known to the server!
 #	Value is acquired from HostnameItem if undefined.
 #
+# Mandatory: no
+# Default:
+# Hostname=
 {% if settings.get('hostname', defaults.get('hostname', False)) %}Hostname={{ settings.get('hostname', defaults.hostname) }}{% endif %}
 
 ### Option: HostnameItem
@@ -45,6 +64,10 @@
 ### Option: ListenPort
 #	Listen port for trapper.
 #
+# Mandatory: no
+# Range: 1024-32767
+# Default:
+# ListenPort=10051
 {% if settings.get('listenport', defaults.get('listenport', False)) %}ListenPort={{ settings.get('listenport', defaults.listenport) }}{% endif %}
 
 ### Option: SourceIP
@@ -62,11 +85,17 @@
 #		file    - file specified with LogFile parameter
 #		console - standard output
 #
+# Mandatory: no
+# Default:
+# LogType=file
 {% if settings.get('logtype', defaults.get('logtype', False)) %}LogType={{ settings.get('logtype', defaults.logtype) }}{% endif %}
 
 ### Option: LogFile
 #	Log file name for LogType 'file' parameter.
 #
+# Mandatory: yes, if LogType is set to file, otherwise no
+# Default:
+# LogFile=
 {% if settings.get('logfile', defaults.get('logfile', False)) %}LogFile={{ settings.get('logfile', defaults.logfile) }}{% endif %}
 
 {% else %}
@@ -81,10 +110,14 @@
 #	Maximum size of log file in MB.
 #	0 - disable automatic log rotation.
 #
+# Mandatory: no
+# Range: 0-1024
+# Default:
+# LogFileSize=1
 {% if settings.get('logfilesize', defaults.get('logfilesize', False)) %}LogFileSize={{ settings.get('logfilesize', defaults.logfilesize) }}{% endif %}
 
 ### Option: DebugLevel
-#	Specifies debug level
+#	Specifies debug level:
 #	0 - basic information about starting and stopping of Zabbix processes
 #	1 - critical information
 #	2 - error information
@@ -93,18 +126,66 @@
 {% if zabbix.version_repo|float >= 3.0 -%}
 #	5 - extended debugging (produces even more information)
 {% endif %}
+#
+# Mandatory: no
+{% if zabbix.version_repo|float >= 3.0 -%}
+# Range: 0-5
+{% else %}
+# Range: 0-4
+{% endif %}
+# Default:
+# DebugLevel=3
 {% if settings.get('debuglevel', defaults.get('debuglevel', False)) %}DebugLevel={{ settings.get('debuglevel', defaults.debuglevel) }}{% endif %}
+
+{% if zabbix.version_repo|float >= 3.4 -%}
+### Option: EnableRemoteCommands
+#       Whether remote commands from Zabbix server are allowed.
+#       0 - not allowed
+#       1 - allowed
+#
+# Mandatory: no
+# Default:
+# EnableRemoteCommands=0
+{% if settings.get('enableremotecommands', defaults.get('enableremotecommands', False)) %}EnableRemoteCommands={{ settings.get('enableremotecommands', defaults.enableremotecommands) }}{% endif %}
+
+### Option: LogRemoteCommands
+#       Enable logging of executed shell commands as warnings.
+#       0 - disabled
+#       1 - enabled
+#
+# Mandatory: no
+# Default:
+# LogRemoteCommands=0
+{% if settings.get('logremotecommands', defaults.get('logremotecommands', False)) %}LogRemoteCommands={{ settings.get('logremotecommands', defaults.logremotecommands) }}{% endif %}
+{% endif %}
 
 ### Option: PidFile
 #	Name of PID file.
 #
+# Mandatory: no
+# Default:
+# PidFile=/tmp/zabbix_proxy.pid
 {% if settings.get('pidfile', defaults.get('pidfile', False)) %}PidFile={{ settings.get('pidfile', defaults.pidfile) }}{% endif %}
+
+{% if zabbix.version_repo|float >= 3.4 -%}
+### Option: SocketDir
+#	IPC socket directory.
+#       Directory to store IPC sockets used by internal Zabbix services.
+#
+# Mandatory: no
+# Default:
+# SocketDir=/tmp
+{% if settings.get('socketdir', defaults.get('socketdir', False)) %}SocketDir={{ settings.get('socketdir', defaults.socketdir) }}{% endif %}
+{% endif %}
 
 ### Option: DBHost
 #	Database host name.
 #	If set to localhost, socket is used for MySQL.
 #	If set to empty string, socket is used for PostgreSQL.
 #
+# Mandatory: no
+# Default:
+# DBHost=localhost
 {% if settings.get('dbhost', defaults.get('dbhost', False)) %}DBHost={{ settings.get('dbhost', defaults.dbhost) }}{% endif %}
 
 ### Option: DBName
@@ -112,32 +193,49 @@
 #	For SQLite3 path to database file must be provided. DBUser and DBPassword are ignored.
 #	Warning: do not attempt to use the same database Zabbix server is using.
 #
+# Mandatory: yes
+# Default:
+# DBName=
 {% if settings.get('dbname', defaults.get('dbname', False)) %}DBName={{ settings.get('dbname', defaults.dbname) }}{% endif %}
 
 ### Option: DBSchema
 #	Schema name. Used for IBM DB2 and PostgreSQL.
 #
+# Mandatory: no
+# Default:
+# DBSchema=
 {% if settings.get('dbschema', defaults.get('dbschema', False)) %}DBSchema={{ settings.get('dbschema', defaults.dbschema) }}{% endif %}
 
 ### Option: DBUser
 #	Database user. Ignored for SQLite.
 #
+# Default:
+# DBUser=
 {% if settings.get('dbuser', defaults.get('dbuser', False)) %}DBUser={{ settings.get('dbuser', defaults.dbuser) }}{% endif %}
 
 ### Option: DBPassword
 #	Database password. Ignored for SQLite.
 #	Comment this line if no password is used.
 #
+# Mandatory: no
+# Default:
+# DBPassword=
 {% if settings.get('dbpass', defaults.get('dbpass', False)) %}DBPassword={{ settings.get('dbpass', defaults.dbpass) }}{% endif %}
 
 ### Option: DBSocket
 #	Path to MySQL socket.
 #
+# Mandatory: no
+# Default:
+# DBSocket=
 {% if settings.get('dbsocket', defaults.get('dbsocket', False)) %}DBSocket={{ settings.get('dbsocket', defaults.dbsocket) }}{% endif %}
 
 # Option: DBPort
 #	Database port when not using local socket. Ignored for SQLite.
 #
+# Mandatory: no
+# Default:
+# DBPort=
 {% if settings.get('dbport', defaults.get('dbport', False)) %}DBPort={{ settings.get('dbport', defaults.dbport) }}{% endif %}
 
 ######### PROXY SPECIFIC PARAMETERS #############
@@ -146,12 +244,20 @@
 #	Proxy will keep data locally for N hours, even if the data have already been synced with the server.
 #	This parameter may be used if local data will be used by third party applications.
 #
+# Mandatory: no
+# Range: 0-720
+# Default:
+# ProxyLocalBuffer=0
 {% if settings.get('proxylocalbuffer', defaults.get('proxylocalbuffer', False)) %}ProxyLocalBuffer={{ settings.get('proxylocalbuffer', defaults.proxylocalbuffer) }}{% endif %}
 
 ### Option: ProxyOfflineBuffer
 #	Proxy will keep data for N hours in case if no connectivity with Zabbix Server.
 #	Older data will be lost.
 #
+# Mandatory: no
+# Range: 1-720
+# Default:
+# ProxyOfflineBuffer=1
 {% if settings.get('proxyofflinebuffer', defaults.get('proxyofflinebuffer', False)) %}ProxyOfflineBuffer={{ settings.get('proxyofflinebuffer', defaults.proxyofflinebuffer) }}{% endif %}
 
 ### Option: HeartbeatFrequency
@@ -160,18 +266,30 @@
 #	0 - heartbeat messages disabled.
 #	For a proxy in the passive mode this parameter will be ignored.
 #
+# Mandatory: no
+# Range: 0-3600
+# Default:
+# HeartbeatFrequency=60
 {% if settings.get('heartbeatfrequency', defaults.get('heartbeatfrequency', False)) %}HeartbeatFrequency={{ settings.get('heartbeatfrequency', defaults.heartbeatfrequency) }}{% endif %}
 
 ### Option: ConfigFrequency
 #	How often proxy retrieves configuration data from Zabbix Server in seconds.
 #	For a proxy in the passive mode this parameter will be ignored.
 #
+# Mandatory: no
+# Range: 1-3600*24*7
+# Default:
+# ConfigFrequency=3600
 {% if settings.get('configfrequency', defaults.get('configfrequency', False)) %}ConfigFrequency={{ settings.get('configfrequency', defaults.configfrequency) }}{% endif %}
 
 ### Option: DataSenderFrequency
 #	Proxy will send collected data to the Server every N seconds.
 #	For a proxy in the passive mode this parameter will be ignored.
 #
+# Mandatory: no
+# Range: 1-3600
+# Default:
+# DataSenderFrequency=1
 {% if settings.get('datasenderfrequency', defaults.get('datasenderfrequency', False)) %}DataSenderFrequency={{ settings.get('datasenderfrequency', defaults.datasenderfrequency) }}{% endif %}
 
 ############ ADVANCED PARAMETERS ################
@@ -179,11 +297,20 @@
 ### Option: StartPollers
 #	Number of pre-forked instances of pollers.
 #
+# Mandatory: no
+# Range: 0-1000
+# Default:
+# StartPollers=5
 {% if settings.get('startpollers', defaults.get('startpollers', False)) %}StartPollers={{ settings.get('startpollers', defaults.startpollers) }}{% endif %}
 
 ### Option: StartIPMIPollers
 #	Number of pre-forked instances of IPMI pollers.
+#       The IPMI manager process is automatically started when at least one IPMI poller is started.
 #
+# Mandatory: no
+# Range: 0-1000
+# Default:
+# StartIPMIPollers=0
 {% if settings.get('startipmipollers', defaults.get('startipmipollers', False)) %}StartIPMIPollers={{ settings.get('startipmipollers', defaults.startipmipollers) }}{% endif %}
 
 ### Option: StartPollersUnreachable
@@ -191,60 +318,103 @@
 #	At least one poller for unreachable hosts must be running if regular, IPMI or Java pollers
 #	are started.
 #
+# Mandatory: no
+# Range: 0-1000
+# Default:
+# StartPollersUnreachable=1
 {% if settings.get('startpollersunreachable', defaults.get('startpollersunreachable', False)) %}StartPollersUnreachable={{ settings.get('startpollersunreachable', defaults.startpollersunreachable) }}{% endif %}
 
 ### Option: StartTrappers
 #	Number of pre-forked instances of trappers.
 #	Trappers accept incoming connections from Zabbix sender and active agents.
 #
+# Mandatory: no
+# Range: 0-1000
+# Default:
+# StartTrappers=5
 {% if settings.get('starttrappers', defaults.get('starttrappers', False)) %}StartTrappers={{ settings.get('starttrappers', defaults.starttrappers) }}{% endif %}
 
 ### Option: StartPingers
 #	Number of pre-forked instances of ICMP pingers.
 #
+# Mandatory: no
+# Range: 0-1000
+# Default:
+# StartPingers=1
 {% if settings.get('startpingers', defaults.get('startpingers', False)) %}StartPingers={{ settings.get('startpingers', defaults.startpingers) }}{% endif %}
 
 ### Option: StartDiscoverers
 #	Number of pre-forked instances of discoverers.
 #
+# Mandatory: no
+# Range: 0-250
+# Default:
+# StartDiscoverers=1
 {% if settings.get('startdiscoverers', defaults.get('startdiscoverers', False)) %}StartDiscoverers={{ settings.get('startdiscoverers', defaults.startdiscoverers) }}{% endif %}
 
 ### Option: StartHTTPPollers
 #	Number of pre-forked instances of HTTP pollers.
 #
+# Mandatory: no
+# Range: 0-1000
+# Default:
+# StartHTTPPollers=1
 {% if settings.get('starthttppollers', defaults.get('starthttppollers', False)) %}StartHTTPPollers={{ settings.get('starthttppollers', defaults.starthttppollers) }}{% endif %}
 
 ### Option: JavaGateway
 #	IP address (or hostname) of Zabbix Java gateway.
 #	Only required if Java pollers are started.
 #
+# Mandatory: no
+# Default:
+# JavaGateway=
 {% if settings.get('starthttppollers', defaults.get('starthttppollers', False)) %}
 JavaGateway={{ settings.get('javagateway', defaults.javagateway) }}
 
 ### Option: JavaGatewayPort
 #	Port that Zabbix Java gateway listens on.
 #
+# Mandatory: no
+# Range: 1024-32767
+# Default:
+# JavaGatewayPort=10052
 JavaGatewayPort={{ settings.get('javagatewayport', defaults.javagatewayport) }}
 
 ### Option: StartJavaPollers
 #	Number of pre-forked instances of Java pollers.
 #
+# Mandatory: no
+# Range: 0-1000
+# Default:
+# StartJavaPollers=0
 StartJavaPollers={{ settings.get('startjavapollers', defaults.startjavapollers) }}
 {% endif %}
 
 ### Option: StartVMwareCollectors
 #	Number of pre-forked vmware collector instances.
 #
+# Mandatory: no
+# Range: 0-250
+# Default:
+# StartVMwareCollectors=0
 {% if settings.get('startvmwarecollectors', defaults.get('startvmwarecollectors', False)) %}StartVMwareCollectors={{ settings.get('startvmwarecollectors', defaults.startvmwarecollectors) }}{% endif %}
 
 ### Option: VMwareFrequency
 #	How often Zabbix will connect to VMware service to obtain a new data.
 #
+# Mandatory: no
+# Range: 10-86400
+# Default:
+# VMwareFrequency=60
 {% if settings.get('vmwarefrequency', defaults.get('vmwarefrequency', False)) %}VMwareFrequency={{ settings.get('vmwarefrequency', defaults.vmwarefrequency) }}{% endif %}
 
 ### Option: VMwarePerfFrequency
 #	How often Zabbix will connect to VMware service to obtain performance data.
 #
+# Mandatory: no
+# Range: 10-86400
+# Default:
+# VMwarePerfFrequency=60
 {% if settings.get('vmwareperffrequency', defaults.get('vmwareperffrequency', False)) %}VMwarePerfFrequency={{ settings.get('vmwareperffrequency', defaults.vmwareperffrequency) }}{% endif %}
 
 ### Option: VMwareCacheSize
@@ -252,11 +422,19 @@ StartJavaPollers={{ settings.get('startjavapollers', defaults.startjavapollers) 
 #	Shared memory size for storing VMware data.
 #	Only used if VMware collectors are started.
 #
+# Mandatory: no
+# Range: 256K-2G
+# Default:
+# VMwareCacheSize=8M
 {% if settings.get('vmwarecachesize', defaults.get('vmwarecachesize', False)) %}VMwareCacheSize={{ settings.get('vmwarecachesize', defaults.vmwarecachesize) }}{% endif %}
 
 ### Option: VMwareTimeout
 #	Specifies how many seconds vmware collector waits for response from VMware service.
 #
+# Mandatory: no
+# Range: 1-300
+# Default:
+# VMwareTimeout=10
 {% if settings.get('vmwaretimeout', defaults.get('vmwaretimeout', False)) %}VMwareTimeout={{ settings.get('vmwaretimeout', defaults.vmwaretimeout) }}{% endif %}
 
 {% if zabbix.version_repo|float < 2.4 -%}
@@ -266,24 +444,33 @@ StartJavaPollers={{ settings.get('startjavapollers', defaults.startjavapollers) 
 #	1 - enable
 #
 {% if settings.get('enablesnmpbulkrequests', defaults.get('enablesnmpbulkrequests', False)) %}EnableSNMPBulkRequests={{ settings.get('enablesnmpbulkrequests', defaults.enablesnmpbulkrequests) }}{% endif %}
-
 {% endif %}
 
 ### Option: SNMPTrapperFile
 #	Temporary file used for passing data from SNMP trap daemon to the proxy.
 #	Must be the same as in zabbix_trap_receiver.pl or SNMPTT configuration file.
 #
+# Mandatory: no
+# Default:
+# SNMPTrapperFile=/tmp/zabbix_traps.tmp
 {% if settings.get('snmptrapperfile', defaults.get('snmptrapperfile', False)) %}SNMPTrapperFile={{ settings.get('snmptrapperfile', defaults.snmptrapperfile) }}{% endif %}
 
 ### Option: StartSNMPTrapper
 #	If 1, SNMP trapper process is started.
 #
+# Mandatory: no
+# Range: 0-1
+# Default:
+# StartSNMPTrapper=0
 {% if settings.get('startsnmptrapper', defaults.get('startsnmptrapper', False)) %}StartSNMPTrapper={{ settings.get('startsnmptrapper', defaults.startsnmptrapper) }}{% endif %}
 
 ### Option: ListenIP
 #	List of comma delimited IP addresses that the trapper should listen on.
 #	Trapper will listen on all network interfaces if this parameter is missing.
 #
+# Mandatory: no
+# Default:
+# ListenIP=0.0.0.0
 {% if settings.get('listenip', defaults.get('listenip', False)) %}ListenIP={{ settings.get('listenip', defaults.listenip) }}{% endif %}
 
 ### Option: HousekeepingFrequency
@@ -298,23 +485,43 @@ StartJavaPollers={{ settings.get('startjavapollers', defaults.startjavapollers) 
 #	period since the last housekeeping cycle, but not less than 4 hours and not greater than 4 days.
 {% endif %}
 #
+# Mandatory: no
+{% if zabbix.version_repo|float >= 3.0 -%}
+# Range: 0-24
+{% else %}
+# Range: 1-24
+{% endif %}
+# Default:
+# HousekeepingFrequency=1
 {% if settings.get('housekeepingfrequency', defaults.get('housekeepingfrequency', False)) %}HousekeepingFrequency={{ settings.get('housekeepingfrequency', defaults.housekeepingfrequency) }}{% endif %}
 
 ### Option: CacheSize
 #	Size of configuration cache, in bytes.
 #	Shared memory size, for storing hosts and items data.
 #
+# Mandatory: no
+# Range: 128K-8G
+# Default:
+# CacheSize=8M
 {% if settings.get('cachesize', defaults.get('cachesize', False)) %}CacheSize={{ settings.get('cachesize', defaults.cachesize) }}{% endif %}
 
 ### Option: StartDBSyncers
-#	Number of pre-forked instances of DB Syncers
+#	Number of pre-forked instances of DB Syncers.
 #
+# Mandatory: no
+# Range: 1-100
+# Default:
+# StartDBSyncers=4
 {% if settings.get('startdbsyncers', defaults.get('startdbsyncers', False)) %}StartDBSyncers={{ settings.get('startdbsyncers', defaults.startdbsyncers) }}{% endif %}
 
 ### Option: HistoryCacheSize
 #	Size of history cache, in bytes.
 #	Shared memory size for storing history data.
 #
+# Mandatory: no
+# Range: 128K-2G
+# Default:
+# HistoryCacheSize=16M
 {% if settings.get('historycachesize', defaults.get('historycachesize', False)) %}HistoryCacheSize={{ settings.get('historycachesize', defaults.historycachesize) }}{% endif %}
 
 {% if zabbix.version_repo|float <= 2.4 -%}
@@ -327,47 +534,78 @@ StartJavaPollers={{ settings.get('startjavapollers', defaults.startjavapollers) 
 
 {% if zabbix.version_repo|float >= 3.0 -%}
 ### Option: HistoryIndexCacheSize
-#   Size of history index cache, in bytes.
-#   Shared memory size for indexing history cache.
+#	Size of history index cache, in bytes.
+#	Shared memory size for indexing history cache.
 #
+# Mandatory: no
+# Range: 128K-2G
+# Default:
+# HistoryIndexCacheSize=4M
 {% if settings.get('historyindexcachesize', defaults.get('historyindexcachesize', False)) %}HistoryIndexCacheSize={{ settings.get('historyindexcachesize', defaults.historyindexcachesize) }}{% endif %}
 {% endif %}
 
 ### Option: Timeout
 #	Specifies how long we wait for agent, SNMP device or external check (in seconds).
 #
+# Mandatory: no
+# Range: 1-30
+# Default:
+# Timeout=3
 {% if settings.get('timeout', defaults.get('timeout', False)) %}Timeout={{ settings.get('timeout', defaults.timeout) }}{% endif %}
 
 ### Option: TrapperTimeout
 #	Specifies how many seconds trapper may spend processing new data.
 #
+# Mandatory: no
+# Range: 1-300
+# Default:
+# TrapperTimeout=300
 {% if settings.get('trappertimeout', defaults.get('trappertimeout', False)) %}TrapperTimeout={{ settings.get('trappertimeout', defaults.trappertimeout) }}{% endif %}
 
 ### Option: UnreachablePeriod
 #	After how many seconds of unreachability treat a host as unavailable.
 #
+# Mandatory: no
+# Range: 1-3600
+# Default:
+# UnreachablePeriod=45
 {% if settings.get('unreachableperiod', defaults.get('unreachableperiod', False)) %}UnreachablePeriod={{ settings.get('unreachableperiod', defaults.unreachableperiod) }}{% endif %}
 
 ### Option: UnavailableDelay
 #	How often host is checked for availability during the unavailability period, in seconds.
 #
+# Mandatory: no
+# Range: 1-3600
+# Default:
+# UnavailableDelay=60
 {% if settings.get('unavaliabledelay', defaults.get('unavaliabledelay', False)) %}UnavailableDelay={{ settings.get('unavaliabledelay', defaults.unavaliabledelay) }}{% endif %}
 
 ### Option: UnreachableDelay
 #	How often host is checked for availability during the unreachability period, in seconds.
 #
+# Mandatory: no
+# Range: 1-3600
+# Default:
+# UnreachableDelay=15
 {% if settings.get('unreachabedelay', defaults.get('unreachabedelay', False)) %}UnreachableDelay={{ settings.get('unreachabedelay', defaults.unreachabedelay) }}{% endif %}
 
 ### Option: ExternalScripts
 #	Full path to location of external scripts.
 #	Default depends on compilation options.
+#	To see the default path run command "zabbix_proxy --help".
 #
+# Mandatory: no
+# Default:
+# ExternalScripts=${datadir}/zabbix/externalscripts
 {% if settings.get('externalscripts', defaults.get('externalscripts', False)) %}ExternalScripts={{ settings.get('externalscripts', defaults.externalscripts) }}{% endif %}
 
 ### Option: FpingLocation
 #	Location of fping.
 #	Make sure that fping binary has root ownership and SUID flag set.
 #
+# Mandatory: no
+# Default:
+# FpingLocation=/usr/sbin/fping
 {% if settings.get('fpinglocation', defaults.get('fpinglocation', False)) %}FpingLocation={{ settings.get('fpinglocation', defaults.fpinglocation) }}{% endif %}
 
 ### Option: Fping6Location
@@ -375,11 +613,17 @@ StartJavaPollers={{ settings.get('startjavapollers', defaults.startjavapollers) 
 #	Make sure that fping6 binary has root ownership and SUID flag set.
 #	Make empty if your fping utility is capable to process IPv6 addresses.
 #
+# Mandatory: no
+# Default:
+# Fping6Location=/usr/sbin/fping6
 {% if settings.get('fping6location', defaults.get('fping6location', False)) %}Fping6Location={{ settings.get('fping6location', defaults.fping6location) }}{% endif %}
 
 ### Option: SSHKeyLocation
 #	Location of public and private keys for SSH checks and actions.
 #
+# Mandatory: no
+# Default:
+# SSHKeyLocation=
 {% if settings.get('sshkeylocation', defaults.get('sshkeylocation', False)) %}SSHKeyLocation={{ settings.get('sshkeylocation', defaults.sshkeylocation) }}{% endif %}
 
 ### Option: LogSlowQueries
@@ -387,11 +631,18 @@ StartJavaPollers={{ settings.get('startjavapollers', defaults.startjavapollers) 
 #	Only works if DebugLevel set to 3 or 4.
 #	0 - don't log slow queries.
 #
+# Mandatory: no
+# Range: 1-3600000
+# Default:
+# LogSlowQueries=0
 {% if settings.get('logslowqueries', defaults.get('logslowqueries', False)) %}LogSlowQueries={{ settings.get('logslowqueries', defaults.logslowqueries) }}{% endif %}
 
 ### Option: TmpDir
 #	Temporary directory.
 #
+# Mandatory: no
+# Default:
+# TmpDir=/tmp
 {% if settings.get('tmpdir', defaults.get('tmpdir', False)) %}TmpDir={{ settings.get('tmpdir', defaults.tmpdir) }}{% endif %}
 
 ### Option: AllowRoot
@@ -401,6 +652,9 @@ StartJavaPollers={{ settings.get('startjavapollers', defaults.startjavapollers) 
 #	0 - do not allow
 #	1 - allow
 #
+# Mandatory: no
+# Default:
+# AllowRoot=0
 {% if settings.get('allowroot', defaults.get('allowroot', False)) %}AllowRoot={{ settings.get('allowroot', defaults.allowroot) }}{% endif %}
 
 {% if zabbix.version_repo|float >= 2.4 -%}
@@ -408,6 +662,9 @@ StartJavaPollers={{ settings.get('startjavapollers', defaults.startjavapollers) 
 #	Drop privileges to a specific, existing user on the system.
 #	Only has effect if run as 'root' and AllowRoot is disabled.
 #
+# Mandatory: no
+# Default:
+# User=zabbix
 {% if settings.get('user', defaults.get('user', False)) %}User={{ settings.get('user', defaults.user) }}{% endif %}
 {% endif %}
 
@@ -415,6 +672,9 @@ StartJavaPollers={{ settings.get('startjavapollers', defaults.startjavapollers) 
 #	You may include individual files or all files in a directory in the configuration file.
 #	Installing Zabbix will create include directory in /usr/local/etc, unless modified during the compile time.
 #
+# Mandatory: no
+# Default:
+# Include=
 {% if 'include' in settings and settings['include'] is string -%}
 {% do settings.update({'includes': [settings['include']]}) -%}
 {% endif -%}
@@ -426,13 +686,23 @@ Include={{ include }}
 ### Option: SSLCertLocation
 #	Location of SSL client certificates.
 #	This parameter is used only in web monitoring.
+#	Default depends on compilation options.
+#	To see the default path run command "zabbix_proxy --help".
 #
+# Mandatory: no
+# Default:
+# SSLCertLocation=${datadir}/zabbix/ssl/certs
 {% if settings.get('sslcertlocation', defaults.get('sslcertlocation', False)) %}SSLCertLocation={{ settings.get('sslcertlocation', defaults.sslcertlocation) }}{% endif %}
 
 ### Option: SSLKeyLocation
 #	Location of private keys for SSL client certificates.
 #	This parameter is used only in web monitoring.
+#	Default depends on compilation options.
+#	To see the default path run command "zabbix_proxy --help".
 #
+# Mandatory: no
+# Default:
+# SSLKeyLocation=${datadir}/zabbix/ssl/keys
 {% if settings.get('sslkeylocation', defaults.get('sslkeylocation', False)) %}SSLKeyLocation={{ settings.get('sslkeylocation', defaults.sslkeylocation) }}{% endif %}
 
 ### Option: SSLCALocation
@@ -440,6 +710,9 @@ Include={{ include }}
 #	If not set, system-wide directory will be used.
 #	This parameter is used only in web monitoring.
 #
+# Mandatory: no
+# Default:
+# SSLCALocation=
 {% if settings.get('sslcalocation', defaults.get('sslcalocation', False)) %}SSLCALocation={{ settings.get('sslcalocation', defaults.sslcalocation) }}{% endif %}
 {% endif %}
 
@@ -448,7 +721,11 @@ Include={{ include }}
 ### Option: LoadModulePath
 #	Full path to location of proxy modules.
 #	Default depends on compilation options.
+#	To see the default path run command "zabbix_proxy --help".
 #
+# Mandatory: no
+# Default:
+# LoadModulePath=${libdir}/modules
 {% if settings.get('loadmodulepath', defaults.get('loadmodulepath', False)) %}LoadModulePath={{ settings.get('loadmodulepath', defaults.loadmodulepath) }}{% endif %}
 
 ### Option: LoadModule
@@ -457,6 +734,9 @@ Include={{ include }}
 #	The modules must be located in directory specified by LoadModulePath.
 #	It is allowed to include multiple LoadModule parameters.
 #
+# Mandatory: no
+# Default:
+# LoadModule=
 {% for loadmodule in settings.get('loadmodules', []) -%}
 LoadModule={{ loadmodule }}
 {% endfor -%}
@@ -492,41 +772,65 @@ LoadModule={{ loadmodule }}
 #	Full pathname of a file containing the top-level CA(s) certificates for
 #	peer certificate verification.
 #
+# Mandatory: no
+# Default:
+# TLSCAFile=
 {% if settings.get('tlscafile', defaults.get('tlscafile', False)) %}TLSCAFile={{ settings.get('tlscafile', defaults.tlscafile) }}{% endif %}
 
 ### Option: TLSCRLFile
 #	Full pathname of a file containing revoked certificates.
 #
+# Mandatory: no
+# Default:
+# TLSCRLFile=
 {% if settings.get('tlscrlfile', defaults.get('tlscrlfile', False)) %}TLSCRLFile={{ settings.get('tlscrlfile', defaults.tlscrlfile) }}{% endif %}
 
 ### Option: TLSServerCertIssuer
 #      Allowed server certificate issuer.
 #
+# Mandatory: no
+# Default:
+# TLSServerCertIssuer=
 {% if settings.get('tlsservercertissuer', defaults.get('tlsservercertissuer', False)) %}TLSServerCertIssuer={{ settings.get('tlsservercertissuer', defaults.tlsservercertissuer) }}{% endif %}
 
 ### Option: TLSServerCertSubject
 #      Allowed server certificate subject.
 #
+# Mandatory: no
+# Default:
+# TLSServerCertSubject=
 {% if settings.get('tlsservercertsubject', defaults.get('tlsservercertsubject', False)) %}TLSServerCertSubject={{ settings.get('tlsservercertsubject', defaults.tlsservercertsubject) }}{% endif %}
 
 ### Option: TLSCertFile
 #	Full pathname of a file containing the proxy certificate or certificate chain.
 #
+# Mandatory: no
+# Default:
+# TLSCertFile=
 {% if settings.get('tlscertfile', defaults.get('tlscertfile', False)) %}TLSCertFile={{ settings.get('tlscertfile', defaults.tlscertfile) }}{% endif %}
 
 ### Option: TLSKeyFile
 #	Full pathname of a file containing the proxy private key.
 #
+# Mandatory: no
+# Default:
+# TLSKeyFile=
 {% if settings.get('tlskeyfile', defaults.get('tlskeyfile', False)) %}TLSKeyFile={{ settings.get('tlskeyfile', defaults.tlskeyfile) }}{% endif %}
 
 ### Option: TLSPSKIdentity
 #	Unique, case sensitive string used to identify the pre-shared key.
 #
+# Mandatory: no
+# Default:
+# TLSPSKIdentity=
 {% if settings.get('tlspskidentity', defaults.get('tlspskidentity', False)) %}TLSPSKIdentity={{ settings.get('tlspskidentity', defaults.tlspskidentity) }}{% endif %}
 
 ### Option: TLSPSKFile
 #	Full pathname of a file containing the pre-shared key.
 #
+# Mandatory: no
+# Default:
+# TLSPSKFile=
 {% if settings.get('tlspskfile', defaults.get('tlspskfile', False)) %}TLSPSKFile={{ settings.get('tlspskfile', defaults.tlspskfile) }}{% endif %}
 {% endif %}
 {{ settings.get('extra_conf','') }}

--- a/zabbix/map.jinja
+++ b/zabbix/map.jinja
@@ -50,6 +50,8 @@
       'logfile': '/var/log/zabbix/zabbix_proxy.log',
       'socketdir': '/var/run/zabbix',
       'externalscripts': '/usr/lib/zabbix/externalscripts',
+      'fpinglocation': '/usr/bin/fping',
+      'fping6location': '/usr/bin/fping6',
       'includes': ['/etc/zabbix/zabbix_proxy.d/']
     },
     'mysql': {

--- a/zabbix/map.jinja
+++ b/zabbix/map.jinja
@@ -48,6 +48,8 @@
       'dbname': '/var/lib/zabbix/zabbix_proxy.db',
       'pidfile': '/var/run/zabbix/zabbix_proxy.pid',
       'logfile': '/var/log/zabbix/zabbix_proxy.log',
+      'socketdir': '/var/run/zabbix',
+      'externalscripts': '/usr/lib/zabbix/externalscripts',
       'includes': ['/etc/zabbix/zabbix_proxy.d/']
     },
     'mysql': {

--- a/zabbix/map.jinja
+++ b/zabbix/map.jinja
@@ -48,6 +48,7 @@
       'dbname': '/var/lib/zabbix/zabbix_proxy.db',
       'pidfile': '/var/run/zabbix/zabbix_proxy.pid',
       'logfile': '/var/log/zabbix/zabbix_proxy.log',
+      'logfilesize': '0',
       'socketdir': '/var/run/zabbix',
       'externalscripts': '/usr/lib/zabbix/externalscripts',
       'fpinglocation': '/usr/bin/fping',


### PR DESCRIPTION
As of today, the current LTS release is 4.0. So I took the chance to compare the current jinja Template against the default file for Debian 9 stretch from: "http://repo.zabbix.com/zabbix/4.0/debian/pool/main/z/zabbix/zabbix-proxy-sqlite3_4.0.3-1%2Bstretch_amd64.deb"
IMHO all the default comments should be completely added to the config file, to make it more understandable. And if I see it correctly, this is already the case for the Zabbix Agent jinja Template. 
I also added missing values for 4.0 with IF querys. 
I also added missing default values for Debian to the map.jinja.