### PR TITLE
BUGFIX: Zabbix proxy service requirement for include folder

### DIFF
--- a/zabbix/proxy/init.sls
+++ b/zabbix/proxy/init.sls
@@ -21,6 +21,9 @@ zabbix-proxy:
       - pkg: zabbix-proxy
       - file: zabbix-proxy-logdir
       - file: zabbix-proxy-piddir
+      {% for include in settings.get('includes', defaults.includes) %}
+      - file: {{ include }}
+      {%- endfor %}
 
 zabbix-proxy-logdir:
   file.directory:


### PR DESCRIPTION
My latest additions (https://github.com/saltstack-formulas/zabbix-formula/commit/ebf90ff56e37d2bf386d2760769c87767e0fa072#diff-de6a2fe5baab4590bf8f8ce616408d7e & https://github.com/saltstack-formulas/zabbix-formula/commit/0b0269c007e94e46e141f64482cdd0b1c1881257#diff-de6a2fe5baab4590bf8f8ce616408d7e) to handle include directory via a FOR loop messed up the "require" for the "service.running" part, as the service now won't start as the folders are created AFTER the "service.running" check. This bug makes the state fail on the very first execution, but it will work on every run after the first one. This commit fixes this.