### PR TITLE
Add Windows Agent functionality

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,6 +88,22 @@ self-contained Zabbix system:
 You need the appropriate mysql, nginx and php formulas to complete the
 installation with this ``top.sls`` file.
 
+If you are installing the zabbix agent for windows you will want to separate the
+pillar for windows from other linux and unix agents
+This is a pillar ``top.sls`` file example to separate windows and Ubuntu Zabbix agent
+pillar files
+
+.. code:: yaml
+
+  base:
+    'os:Ubuntu':
+      - match: grain
+      - zabbix-agent-ubuntu
+      
+    'os:Windows':
+      - match: grain
+      - zabbix-agent-windows
+
 .. note::
 
     See the full `Salt Formulas

--- a/pillar.example
+++ b/pillar.example
@@ -42,6 +42,33 @@ zabbix-agent:
   extra_conf: |
     # Here we can set extra agent configuration lines
 
+## Zabbix Agent for Windows ##
+zabbix-agent:
+  server:
+    - zabbix.example.com
+  serveractive:
+    - localhost
+  listenip: 0.0.0.0
+  listenport: 10050
+  hostmetadata: c9767034-22c6-4d3d-a886-5fcaf1386b77
+  # For zabbix-agent below version 3 if you want to use syslog instead of file specify
+  # logfile: syslog
+  logfile: 'C:\program files\zabbix agent\zabbix_agentd.log'
+  logfilesize: 0
+  include: 'C:\program files\zabbix agent\zabbix_agentd.d\'
+  # Or multiple "Include" options
+  includes:
+    - 'C:\program files\zabbix agent\zabbix_agentd.d\'
+    - 'C:\some\custom\location\'
+   # Pidfiles will break the windows agent so please don't add them.
+## lookup config for windows agent ##
+zabbix:
+  lookup:
+    agent:
+      version: '3.0.28.2400'
+      ## Because of the way winrepo-ng works you have to have the FULL agent version
+      ## Check the zabbix-agent in winrepo-ng for current versions, or create your own pkg file
+
 zabbix-server:
   listenip: 0.0.0.0
   listenport: 10051

--- a/pillar.example
+++ b/pillar.example
@@ -27,8 +27,6 @@ zabbix-agent:
   listenip: 0.0.0.0
   listenport: 10050
   hostmetadata: c9767034-22c6-4d3d-a886-5fcaf1386b77
-  # For zabbix-agent below version 3 if you want to use syslog instead of file specify
-  # logfile: syslog
   logfile: /var/log/zabbix/zabbix_agentd.log
   logfilesize: 0
   include: /etc/zabbix/zabbix_agentd.d/

--- a/pillar.example
+++ b/pillar.example
@@ -54,7 +54,7 @@ zabbix-agent:
   # For zabbix-agent below version 3 if you want to use syslog instead of file specify
   # logfile: syslog
   logfile: 'C:\program files\zabbix agent\zabbix_agentd.log'
-  logfilesize: 0
+  logfilesize: 5
   include: 'C:\program files\zabbix agent\zabbix_agentd.d\'
   # Or multiple "Include" options
   includes:

--- a/zabbix/agent/init.sls
+++ b/zabbix/agent/init.sls
@@ -2,8 +2,10 @@
 {% set settings = salt['pillar.get']('zabbix-agent', {}) -%}
 {% set defaults = zabbix.get('agent', {}) -%}
 
+{% if salt['grains.get']('os') != 'Windows' %}
 include:
   - zabbix.users
+{% endif %}
 
 zabbix-agent:
   pkg.installed:
@@ -11,16 +13,20 @@ zabbix-agent:
       {%- for name in zabbix.agent.pkgs %}
       - {{ name }}{% if zabbix.agent.version is defined and 'zabbix' in name %}: '{{ zabbix.agent.version }}'{% endif %}
       {%- endfor %}
+{% if salt['grains.get']('os') != 'Windows' %}
     - require_in:
       - user: zabbix-formula_zabbix_user
       - group: zabbix-formula_zabbix_group
+{% endif %}
   service.running:
     - name: {{ zabbix.agent.service }}
     - enable: True
     - require:
       - pkg: zabbix-agent
       - file: zabbix-agent-logdir
+{% if salt['grains.get']('os') != 'Windows' %}
       - file: zabbix-agent-piddir
+{% endif %}
 
 zabbix-agent-restart:
   module.wait:
@@ -36,6 +42,7 @@ zabbix-agent-logdir:
     - require:
       - pkg: zabbix-agent
 
+{% if salt['grains.get']('os') != 'Windows' %}
 zabbix-agent-piddir:
   file.directory:
     - name: {{ salt['file.dirname'](zabbix.agent.pidfile) }}
@@ -44,6 +51,7 @@ zabbix-agent-piddir:
     - dirmode: 750
     - require:
       - pkg: zabbix-agent
+{% endif %}
 
 {% for include in settings.get('includes', defaults.get('includes', [])) %}
 {{ include }}:

--- a/zabbix/map.jinja
+++ b/zabbix/map.jinja
@@ -158,6 +158,7 @@
       'service': 'Zabbix Agent',
       'config': 'C:\\Program Files\\Zabbix Agent\\zabbix_agentd.conf',
       'logfile': 'C:\\Program Files\\Zabbix Agent\\zabbix_agentd.log',
+      'logfilesize': '5',
       'pidfile': '',
       'includes': [],
     },

--- a/zabbix/map.jinja
+++ b/zabbix/map.jinja
@@ -149,6 +149,20 @@
     },
   },
 
+  'Windows':{
+    'user': 'Administrator',
+    'group': 'Administrators',
+    'agent': {
+      'version': '3.0.28.2400',
+      'pkgs': ['zabbix-agent'],
+      'service': 'Zabbix Agent',
+      'config': 'C:\\Program Files\\Zabbix Agent\\zabbix_agentd.conf',
+      'logfile': 'C:\\Program Files\\Zabbix Agent\\zabbix_agentd.log',
+      'pidfile': '',
+      'includes': [],
+    },
+  },
+
   'default': {
     'version_repo': '2.2',
     'user': 'zabbix',


### PR DESCRIPTION
This addresses issue #112,  some requirements for this are having a salt windows repo setup and having a zabbix agent installer definition in that windows repo.  There is currently a pull request pending to add a zabbix-agent definition to the windows repo for the saltstack windows-ng repo