### PR TITLE
Zabbix proxy sqlitedir - Need help

### DIFF
--- a/zabbix/proxy/init.sls
+++ b/zabbix/proxy/init.sls
@@ -21,6 +21,7 @@ zabbix-proxy:
       - pkg: zabbix-proxy
       - file: zabbix-proxy-logdir
       - file: zabbix-proxy-piddir
+      - file: zabbix-proxy-sqlitedir
       {% for include in settings.get('includes', defaults.get('includes', [])) %}
       - file: {{ include }}
       {%- endfor %}
@@ -37,6 +38,15 @@ zabbix-proxy-logdir:
 zabbix-proxy-piddir:
   file.directory:
     - name: {{ salt['file.dirname'](zabbix.proxy.pidfile) }}
+    - user: {{ zabbix.user }}
+    - group: {{ zabbix.group }}
+    - dirmode: 750
+    - require:
+      - pkg: zabbix-proxy
+      
+zabbix-proxy-sqlitedir:
+  file.directory:
+    - name: {{ salt['file.dirname'](zabbix.proxy.dbname) }}
     - user: {{ zabbix.user }}
     - group: {{ zabbix.group }}
     - dirmode: 750

--- a/zabbix/proxy/init.sls
+++ b/zabbix/proxy/init.sls
@@ -21,6 +21,9 @@ zabbix-proxy:
       - pkg: zabbix-proxy
       - file: zabbix-proxy-logdir
       - file: zabbix-proxy-piddir
+      {% for include in settings.get('includes', defaults.includes) %}
+      - file: {{ include }}
+      {%- endfor %}
 
 zabbix-proxy-logdir:
   file.directory:

--- a/zabbix/proxy/init.sls
+++ b/zabbix/proxy/init.sls
@@ -21,7 +21,6 @@ zabbix-proxy:
       - pkg: zabbix-proxy
       - file: zabbix-proxy-logdir
       - file: zabbix-proxy-piddir
-      - file: zabbix-proxy-sqlitedir
       {% for include in settings.get('includes', defaults.get('includes', [])) %}
       - file: {{ include }}
       {%- endfor %}
@@ -43,7 +42,9 @@ zabbix-proxy-piddir:
     - dirmode: 750
     - require:
       - pkg: zabbix-proxy
-      
+
+# basic check does 'dbname' looks like a file path
+{% if zabbix.proxy.dbname.startswith('/') -%}      
 zabbix-proxy-sqlitedir:
   file.directory:
     - name: {{ salt['file.dirname'](zabbix.proxy.dbname) }}
@@ -52,6 +53,9 @@ zabbix-proxy-sqlitedir:
     - dirmode: 750
     - require:
       - pkg: zabbix-proxy
+- watch_in:
+  - service: zabbix-proxy
+{%- endif %}
 
 {% for include in settings.get('includes', defaults.get('includes', [])) %}
 {{ include }}:

--- a/zabbix/repo.sls
+++ b/zabbix/repo.sls
@@ -23,7 +23,7 @@
 {% if salt['grains.get']('os_family') == 'Debian' -%}
 {{ id_prefix }}_repo:
   pkgrepo.managed:
-    - name: deb http://repo.zabbix.com/zabbix/{{ zabbix.version_repo }}/{{ salt['grains.get']('os')|lower }} {{ salt['grains.get']('oscodename') }} main
+    - name: deb https://repo.zabbix.com/zabbix/{{ zabbix.version_repo }}/{{ salt['grains.get']('os')|lower }} {{ salt['grains.get']('oscodename') }} main
     - file: /etc/apt/sources.list.d/zabbix.list
     - key_url: https://repo.zabbix.com/zabbix-official-repo.key
     - clean_file: True

--- a/zabbix/repo.sls
+++ b/zabbix/repo.sls
@@ -23,7 +23,7 @@
 {% if salt['grains.get']('os_family') == 'Debian' -%}
 {{ id_prefix }}_repo:
   pkgrepo.managed:
-    - name: deb https://repo.zabbix.com/zabbix/{{ zabbix.version_repo }}/{{ salt['grains.get']('os')|lower }} {{ salt['grains.get']('oscodename') }} main
+    - name: deb http://repo.zabbix.com/zabbix/{{ zabbix.version_repo }}/{{ salt['grains.get']('os')|lower }} {{ salt['grains.get']('oscodename') }} main
     - file: /etc/apt/sources.list.d/zabbix.list
     - key_url: https://repo.zabbix.com/zabbix-official-repo.key
     - clean_file: True


### PR DESCRIPTION
As many people use SQLite for Zabbix proxy, I think it's obvious that the definition of a SQLite in the pillar database has to create the directory. I handled that in a separate state until now, but I find it odd that the official formula has to fail inevitable, because the Zabbix proxy daemon will never launch, because the directory is missing. 
But this pull request has a big drawback I think. I someone would like to use a real MySQL or MariaDB, this shouldn't be executed. 
I need some kind of IF statement, that will check if `dbname` contains a word or a path. I wasn't able to fix that yet. If we solve that, this will be a very helpful addition, as the formula will fail otherwise for all SQLite users. 