### PR TITLE
Update 'include' mapping

### DIFF
--- a/zabbix/map.jinja
+++ b/zabbix/map.jinja
@@ -14,7 +14,7 @@
       'logfilesize': '0',
       'server': ['127.0.0.1'],
       'serveractive': ['127.0.0.1'],
-      'includes': ['/etc/zabbix/zabbix_agentd.d/']
+      'includes': ['/etc/zabbix/zabbix_agentd.d/*.conf']
     },
     'server': {
       'pkgs': ['zabbix-server-mysql', 'zabbix-get'],
@@ -53,7 +53,7 @@
       'externalscripts': '/usr/lib/zabbix/externalscripts',
       'fpinglocation': '/usr/bin/fping',
       'fping6location': '/usr/bin/fping6',
-      'includes': ['/etc/zabbix/zabbix_proxy.d/']
+      'includes': ['/etc/zabbix/zabbix_proxy.d/*.conf']
     },
     'mysql': {
       'pkgs': ['python-mysqldb']
@@ -164,7 +164,7 @@
       'logfilesize': '0',
       'server': ['127.0.0.1'],
       'serveractive': ['127.0.0.1'],
-      'includes': ['/etc/zabbix/zabbix_agentd.d/']
+      'includes': ['/etc/zabbix/zabbix_agentd.d/*.conf']
     },
     'server': {
       'pkgs': ['zabbix-server-mysql', 'zabbix-get'],


### PR DESCRIPTION
Change 'include' mapping from /etc/zabbix/zabbix_agent.d/ to /etc/zabbix/zabbix_agentd.d/*.conf to load only conf files when Zabbix starts. This config is default in zabbix_agentd.conf but in Zabbix Formula is different. I suggest to change /etc/zabbix/zabbix_proxy.d/ to