### PR TITLE
Switch Debian apt repo to https (2nd try)

### DIFF
--- a/zabbix/repo.sls
+++ b/zabbix/repo.sls
@@ -21,8 +21,9 @@
 
 
 {% if salt['grains.get']('os_family') == 'Debian' -%}
-apt-transport-https:
-  pkg.installed
+{{ id_prefix }}_apt-transport-https:
+  pkg.installed:
+    - name: apt-transport-https
 {{ id_prefix }}_repo:
   pkgrepo.managed:
     - name: deb https://repo.zabbix.com/zabbix/{{ zabbix.version_repo }}/{{ salt['grains.get']('os')|lower }} {{ salt['grains.get']('oscodename') }} main

--- a/zabbix/repo.sls
+++ b/zabbix/repo.sls
@@ -25,7 +25,7 @@ apt-transport-https:
   pkg.installed
 {{ id_prefix }}_repo:
   pkgrepo.managed:
-    - name: deb http://repo.zabbix.com/zabbix/{{ zabbix.version_repo }}/{{ salt['grains.get']('os')|lower }} {{ salt['grains.get']('oscodename') }} main
+    - name: deb https://repo.zabbix.com/zabbix/{{ zabbix.version_repo }}/{{ salt['grains.get']('os')|lower }} {{ salt['grains.get']('oscodename') }} main
     - file: /etc/apt/sources.list.d/zabbix.list
     - key_url: https://repo.zabbix.com/zabbix-official-repo.key
     - clean_file: True


### PR DESCRIPTION
@aboe76 I'm very sorry, I must have made a mistake, the "apt-transport-https" was added, but not the URL change. 