### PR TITLE
Breaking Change: Update default version to 3.0 LTS

### DIFF
--- a/zabbix/map.jinja
+++ b/zabbix/map.jinja
@@ -1,6 +1,6 @@
 {% set zabbix = salt['grains.filter_by']({
   'Debian': {
-    'version_repo': '2.2',
+    'version_repo': '3.0',
     'user': 'zabbix',
     'group': 'zabbix',
     'home': '/var/lib/zabbix',
@@ -66,7 +66,7 @@
   },
 
   'RedHat': {
-    'version_repo': '2.2',
+    'version_repo': '3.0',
     'user': 'zabbix',
     'group': 'zabbix',
     'shell': '/sbin/nologin',
@@ -107,7 +107,7 @@
   },
 
   'FreeBSD': {
-    'version_repo': '2.2',
+    'version_repo': '3.0',
     'user': 'zabbix',
     'group': 'zabbix',
     'home': '/var/lib/zabbix',
@@ -138,7 +138,7 @@
   },
 
   'OpenBSD': {
-    'version_repo': '2.4',
+    'version_repo': '3.0',
     'user': '_zabbix',
     'group': '_zabbix',
     'shell': '/sbin/nologin',
@@ -167,7 +167,7 @@
   },
 
   'default': {
-    'version_repo': '2.2',
+    'version_repo': '3.0',
     'user': 'zabbix',
     'group': 'zabbix',
     'home': '/var/lib/zabbix',


### PR DESCRIPTION
As suggested by @hatifnatt in #87 we should finally switch to 3.0 LTS, as 4.0 LTS is already available. 

What do the others think? =)