### PR TITLE
Zabbix services should restart if pkg changes

### DIFF
--- a/zabbix/agent/init.sls
+++ b/zabbix/agent/init.sls
@@ -27,6 +27,8 @@ zabbix-agent:
 {% if salt['grains.get']('os') != 'Windows' %}
       - file: zabbix-agent-piddir
 {% endif %}
+    - watch:
+      - pkg: zabbix-agent
 
 zabbix-agent-restart:
   module.wait:

--- a/zabbix/proxy/init.sls
+++ b/zabbix/proxy/init.sls
@@ -24,6 +24,8 @@ zabbix-proxy:
       {% for include in settings.get('includes', defaults.get('includes', [])) %}
       - file: {{ include }}
       {%- endfor %}
+    - watch:
+      - pkg: zabbix-proxy
 
 zabbix-proxy-logdir:
   file.directory:

--- a/zabbix/server/init.sls
+++ b/zabbix/server/init.sls
@@ -22,6 +22,8 @@ zabbix-server:
       - pkg: zabbix-server
       - file: zabbix-server-logdir
       - file: zabbix-server-piddir
+    - watch:
+      - pkg: zabbix-server
 
 zabbix-server-logdir:
   file.directory:


### PR DESCRIPTION
I started playing around with forced version updates, and noticed that even if the packages install successfully, the service doesn't notice it. This PR could fix that. 

Example:
`/srv/pillar/zabbix/init.sls`
```
# Overrides map.jinja
zabbix:
  lookup:
    version_repo: 4.0
    agent:
      version: 1:4.0.13-1+stretch
    proxy:
      version: 1:4.0.13-1+stretch
```