### PR TITLE
fix(pgsql): do not try to create db and user with schema

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -197,15 +197,20 @@ Creates database and mysql user for Zabbix.
 
 Creates mysql schema for Zabbix.
 
+``zabbix.pgsql.pkgs``
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Install required psql packages.
+
 ``zabbix.pgsql.conf``
 ^^^^^^^^^^^^^^^^^^^^^
 
-Creates database and PostgreSQL user for Zabbix.
+Creates database and PostgreSQL user for Zabbix. Includes zabbix.pgsql.pkgs.
 
 ``zabbix.pgsql.schema``
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Creates PostgreSQL schema for Zabbix.
+Creates PostgreSQL schema for Zabbix. Includes zabbix.pgsql.pkgs.
 
 ``zabbix.proxy``
 ^^^^^^^^^^^^^^^^

--- a/zabbix/pgsql/conf.sls
+++ b/zabbix/pgsql/conf.sls
@@ -10,36 +10,8 @@
 {% set dbroot_user = settings.get('dbroot_user') -%}
 {% set dbroot_pass = settings.get('dbroot_pass') -%}
 
-# Install packages required for Salt postgres module
-{% if settings.get('pkgs', defaults.get('pkgs', False))
-      and not settings.get('skip_pkgs', defaults.skip_pkgs) -%}
-pgsql_packages:
-  pkg.installed:
-    - pkgs: {{ settings.get('pkgs', defaults.pkgs)|json }}
-{% elif settings.get('skip_pkgs', defaults.skip_pkgs) -%}
-pgsql_packages:
-  test.configurable_test_state:
-    - name: You skipped installation of packages required for Salt postgres module.
-    - changes: False
-    - result: True
-{% else -%}
-pgsql_packages:
-  test.configurable_test_state:
-    - name: Packages required for Salt postgres module are not defined
-    - changes: False
-    - result: False
-    - comment: |
-        Additional packages are required to manage the PostgreSQL database.
-        Please specify them in pillar as list.
-        Tip: you need postgresql-client packages, like:
-        zabbix-pgsql:
-          pkgs:
-            - postgresql-client-common
-            - postgresql-client
-        Or you can skip installing them, but formula likely fail without them.
-        zabbix-pgsql:
-          skip_pkgs: True
-{% endif -%}
+include:
+  - zabbix.pgsql.pkgs
 
 zabbix_pgsql_user:
   postgres_user.present:

--- a/zabbix/pgsql/pkgs.sls
+++ b/zabbix/pgsql/pkgs.sls
@@ -1,0 +1,34 @@
+{% from "zabbix/map.jinja" import zabbix with context -%}
+{% set settings = salt['pillar.get']('zabbix-pgsql', {}) -%}
+{% set defaults = zabbix.get('pgsql', {}) -%}
+
+# Install packages required for Salt postgres module
+{% if settings.get('pkgs', defaults.get('pkgs', False))
+      and not settings.get('skip_pkgs', defaults.skip_pkgs) -%}
+pgsql_packages:
+  pkg.installed:
+    - pkgs: {{ settings.get('pkgs', defaults.pkgs)|json }}
+{% elif settings.get('skip_pkgs', defaults.skip_pkgs) -%}
+pgsql_packages:
+  test.configurable_test_state:
+    - name: You skipped installation of packages required for Salt postgres module.
+    - changes: False
+    - result: True
+{% else -%}
+pgsql_packages:
+  test.configurable_test_state:
+    - name: Packages required for Salt postgres module are not defined
+    - changes: False
+    - result: False
+    - comment: |
+        Additional packages are required to manage the PostgreSQL database.
+        Please specify them in pillar as list.
+        Tip: you need postgresql-client packages, like:
+        zabbix-pgsql:
+          pkgs:
+            - postgresql-client-common
+            - postgresql-client
+        Or you can skip installing them, but formula likely fail without them.
+        zabbix-pgsql:
+          skip_pkgs: True
+{% endif -%}

--- a/zabbix/pgsql/schema.sls
+++ b/zabbix/pgsql/schema.sls
@@ -28,7 +28,7 @@
 {% endif -%}
 
 include:
-  - zabbix.pgsql.conf
+  - zabbix.pgsql.pkgs
 
 check_db_pgsql:
   test.configurable_test_state:


### PR DESCRIPTION
### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->
- [x] `[fix]`      A bug fix
I was condering if to make it a feat or fix, but i decided for a fix, because it is not documented that the schema also automatically created DB and User (in i think it shouldn't, that's that zabbix.pgsql.conf is for)

### Does this PR introduce a `BREAKING CHANGE`?
Unlikely.
I assume that people who want to both create db/user and a schema, use both states, zabbix.pgsql.conf and zabbix.pgsql.schema as documentation says. Potentially someone can be using only zabbix.pgsql.schema and rely on the sideeffect to create a db/user, in that case they need start to use also zabbix.pgsql.conf

### Describe the changes you're proposing
Split off required packages to separate state, so zabbix.pgsql.schema can be used independently from zabbix.pgsql.conf. Especially useful if you want to use remote db and for security reasons postgres user cannot login remotely.

### Pillar / config required to test the proposed changes
use state zabbix.pgsql.schema

### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [x] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.
