### PR TITLE
feat(frontend): allow to set that db history tables were updated (zabbix 5.0+)

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -174,6 +174,13 @@ zabbix:
       # unset dbsocket, it's not used with PostgreSQL
       dbsocket: ""
 
+# Example with DB upgraded for >=5.0
+zabbix:
+  lookup:
+    version_repo: 5.4
+    frontend:
+      historyupgraded: true
+
 zabbix-pgsql:
   # By default SQL dump provided by Zabbix package will be used, but you can
   # put your own dump in corresponding directory (consult with TOFS_pattern.md)

--- a/zabbix/defaults.yaml
+++ b/zabbix/defaults.yaml
@@ -55,6 +55,7 @@ zabbix:
     zbxserver: localhost
     zbxserverport: '10051'
     zbxservername: Zabbix installed with SaltStack
+    historyupgraded: false
   proxy:
     pkgs:
       - zabbix-proxy-sqlite3

--- a/zabbix/files/default/etc/zabbix/web/zabbix.conf.php.jinja
+++ b/zabbix/files/default/etc/zabbix/web/zabbix.conf.php.jinja
@@ -23,4 +23,7 @@ $ZBX_SERVER_PORT		= '{{ settings.get('zbxserverport', defaults.zbxserverport) }}
 $ZBX_SERVER_NAME		= '{{ settings.get('zbxservername', defaults.zbxservername) }}';
 
 $IMAGE_FORMAT_DEFAULT	= IMAGE_FORMAT_PNG;
+{% if defaults['historyupgraded'] -%}
+$DB['DOUBLE_IEEE754'] = 'true';
+{% endif -%}
 ?>


### PR DESCRIPTION
### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [x] `[feat]`     A new feature

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [x] `[docs]`     Documentation changes

### Does this PR introduce a `BREAKING CHANGE`?

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->



### Describe the changes you're proposing
Zabbix 5.0 will complain in froentend with "Database history tables upgraded | No" unless a variable is set ij web connfig file. Unfortunately upgrading the tables is not enough, it needs to be told in config too. This should be done in pillar when upgrading.



### Pillar / config required to test the proposed changes
```
zabbix:
  lookup:
    version_repo: 5.4
    frontend:
      historyupgraded: true
```


### Debug log showing how the proposed changes work
```
          ID: /etc/zabbix/web/zabbix.conf.php
    Function: file.managed
      Result: True
     Comment: File /etc/zabbix/web/zabbix.conf.php updated
     Started: 14:52:25.967616
    Duration: 224.967 ms
     Changes:   
              ----------
              diff:
                  --- 
                  +++ 
                  @@ -16,4 +16,5 @@
                   $ZBX_SERVER_NAME             = 'Zabbix installed with SaltStack';
                   
                   $IMAGE_FORMAT_DEFAULT        = IMAGE_FORMAT_PNG;
                  +$DB['DOUBLE_IEEE754'] = 'true';
                   ?>
```
### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [x] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


