### PR TITLE
The default version is very old and not available in repos anymore.

### DIFF
--- a/zabbix/osfamilymap.yaml
+++ b/zabbix/osfamilymap.yaml
@@ -11,7 +11,7 @@
 # osfamilymap: {}
 ---
 Debian:
-  version_repo: 2.2
+  version_repo: 5.5
   user: zabbix
   group: zabbix
   home: /var/lib/zabbix
@@ -84,7 +84,7 @@ Debian:
       - postgresql-client
 
 RedHat:
-  version_repo: 2.2
+  version_repo: 5.5
   user: zabbix
   group: zabbix
   shell: /sbin/nologin
@@ -171,7 +171,7 @@ Suse:
 
 
 FreeBSD:
-  version_repo: 2.2
+  version_repo: 5.5
   user: zabbix
   group: zabbix
   home: /var/lib/zabbix
@@ -201,7 +201,7 @@ FreeBSD:
     logfile: /var/log/zabbix/zabbix_proxy.log
 
 OpenBSD:
-  version_repo: 2.4
+  version_repo: 5.5
   user: _zabbix
   group: _zabbix
   shell: /sbin/nologin
@@ -217,7 +217,7 @@ Windows:
   user: Administrator
   group: Administrators
   agent:
-    version: 3.0
+    version: 5.5
     pkgs:
       - zabbix-agent
     service: Zabbix Agent

--- a/zabbix/osfingermap.yaml
+++ b/zabbix/osfingermap.yaml
@@ -11,6 +11,7 @@
 # osfingermap: {}
 ---
 # os: Debian
+Debian-11: {}
 Debian-10: {}
 Debian-9: {}
 Debian-8: {}


### PR DESCRIPTION
The default version of packages is very old and not available in repos anymore. We bump it up to the latest so the formula works out of the box.